### PR TITLE
Fix - Close outdated alerts on Github Security tab

### DIFF
--- a/commands/createfixpullrequests_test.go
+++ b/commands/createfixpullrequests_test.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	clientLog "github.com/jfrog/jfrog-client-go/utils/log"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -181,6 +182,8 @@ func TestPackageTypeFromScan(t *testing.T) {
 		t.Run(pkgType.ToString(), func(t *testing.T) {
 			frogbotParams.WorkingDirectory = projectPath
 			scanResponse, err := testScan.scan(&frogbotParams)
+			clientLog.Info("err: %s", err)
+			clientLog.Info(scanResponse)
 			assert.NoError(t, err)
 			verifyTechnologyNaming(t, scanResponse, pkgType)
 		})
@@ -190,6 +193,7 @@ func TestPackageTypeFromScan(t *testing.T) {
 func verifyTechnologyNaming(t *testing.T, scanResponse []services.ScanResponse, expectedType coreutils.Technology) {
 	for _, resp := range scanResponse {
 		for _, vulnerability := range resp.Vulnerabilities {
+			clientLog.Info("Expected %s, actual %s", expectedType.ToString(), vulnerability.Technology)
 			assert.Equal(t, expectedType.ToString(), vulnerability.Technology)
 		}
 	}

--- a/commands/createfixpullrequests_test.go
+++ b/commands/createfixpullrequests_test.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	clientLog "github.com/jfrog/jfrog-client-go/utils/log"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -182,8 +181,7 @@ func TestPackageTypeFromScan(t *testing.T) {
 		t.Run(pkgType.ToString(), func(t *testing.T) {
 			frogbotParams.WorkingDirectory = projectPath
 			scanResponse, err := testScan.scan(&frogbotParams)
-			clientLog.Info("err: %s", err)
-			clientLog.Info(scanResponse)
+
 			assert.NoError(t, err)
 			verifyTechnologyNaming(t, scanResponse, pkgType)
 		})
@@ -193,7 +191,6 @@ func TestPackageTypeFromScan(t *testing.T) {
 func verifyTechnologyNaming(t *testing.T, scanResponse []services.ScanResponse, expectedType coreutils.Technology) {
 	for _, resp := range scanResponse {
 		for _, vulnerability := range resp.Vulnerabilities {
-			clientLog.Info("Expected %s, actual %s", expectedType.ToString(), vulnerability.Technology)
 			assert.Equal(t, expectedType.ToString(), vulnerability.Technology)
 		}
 	}

--- a/commands/utils/utils.go
+++ b/commands/utils/utils.go
@@ -76,10 +76,7 @@ func UploadScanToGitProvider(scanResults []services.ScanResponse, params *Frogbo
 		clientLog.Debug("Upload Scan to " + params.GitProvider.String() + " is currently unsupported.")
 		return nil
 	}
-	// Don't do anything if scanResults is empty
-	if xrayutils.IsEmptyScanResponse(scanResults) {
-		return nil
-	}
+
 	includeVulnerabilities := params.Project == "" && params.Watches == ""
 	scan, err := xrayutils.GenerateSarifFileFromScan(scanResults, includeVulnerabilities, false)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,11 @@ go 1.18
 require (
 	github.com/go-git/go-git/v5 v5.4.2
 	github.com/golang/mock v1.6.0
-	github.com/jfrog/build-info-go v1.8.0
+	github.com/jfrog/build-info-go v1.8.1
 	github.com/jfrog/froggit-go v1.3.2
 	github.com/jfrog/gofrog v1.2.4
-	github.com/jfrog/jfrog-cli-core/v2 v2.23.2
-	github.com/jfrog/jfrog-client-go v1.24.1
+	github.com/jfrog/jfrog-cli-core/v2 v2.24.0
+	github.com/jfrog/jfrog-client-go v1.24.2
 	github.com/stretchr/testify v1.8.0
 	github.com/urfave/cli/v2 v2.11.2
 )

--- a/go.mod
+++ b/go.mod
@@ -97,6 +97,6 @@ require (
 
 // replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.21.1-0.20220828160454-7c617b0d1582
 
-// replace github.com/jfrog/jfrog-cli-core/v2 => github.com/sverdlov93/jfrog-cli-core/v2 v2.0.2-0.20221024142700-41015bd6517c
+replace github.com/jfrog/jfrog-cli-core/v2 => github.com/jfrog/jfrog-cli-core/v2 v2.24.1-0.20221103225532-344398c1ebbd
 
 // replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v1.4.2-0.20220825155547-eff444e96d62

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/jfrog/build-info-go v1.8.1
 	github.com/jfrog/froggit-go v1.3.2
 	github.com/jfrog/gofrog v1.2.4
-	github.com/jfrog/jfrog-cli-core/v2 v2.24.0
+	github.com/jfrog/jfrog-cli-core/v2 v2.23.2
 	github.com/jfrog/jfrog-client-go v1.24.2
 	github.com/stretchr/testify v1.8.0
 	github.com/urfave/cli/v2 v2.11.2

--- a/go.sum
+++ b/go.sum
@@ -217,8 +217,8 @@ github.com/jfrog/froggit-go v1.3.2 h1:fkzsI13vQkZZ2eZiN1Pyq+ZNxlJ4lLF/jZ/MuUx8uk
 github.com/jfrog/froggit-go v1.3.2/go.mod h1:QPE1t+DTKgp7TxLQ1ZftDQVzkCHXAyYQskLGAKQe8yM=
 github.com/jfrog/gofrog v1.2.4 h1:PDk/TFUz6HFvXIdoVI4UFzeoVocMVIu+YkROKHJXCOY=
 github.com/jfrog/gofrog v1.2.4/go.mod h1:lbkGXX/DHKdomaSV34eiOC3pAr1HRNa9ffOYh7U7b1U=
-github.com/jfrog/jfrog-cli-core/v2 v2.24.0 h1:bGoJqkpGr6RxNpO/0+7ybPrpG4Q8ExNYrwXoSPfeANg=
-github.com/jfrog/jfrog-cli-core/v2 v2.24.0/go.mod h1:dtcFGR/ep+dBNzwJ9mf2YgI3d9+1sTbdU9HTmLeN4TE=
+github.com/jfrog/jfrog-cli-core/v2 v2.24.1-0.20221103225532-344398c1ebbd h1:ymYJsGj+Y+XmkasU+uXOKaQB0jCj9083E8lNTSTee98=
+github.com/jfrog/jfrog-cli-core/v2 v2.24.1-0.20221103225532-344398c1ebbd/go.mod h1:dtcFGR/ep+dBNzwJ9mf2YgI3d9+1sTbdU9HTmLeN4TE=
 github.com/jfrog/jfrog-client-go v1.24.2 h1:FjF6TQQs1VVnY/oYkWt3yR4aS0O9aQ37Te+j/QIu2hw=
 github.com/jfrog/jfrog-client-go v1.24.2/go.mod h1:cUi4SuJqQ7miwfRi9dnGaWiSGJoi7bVmuxZy+OJfXw4=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=

--- a/go.sum
+++ b/go.sum
@@ -217,6 +217,8 @@ github.com/jfrog/froggit-go v1.3.2 h1:fkzsI13vQkZZ2eZiN1Pyq+ZNxlJ4lLF/jZ/MuUx8uk
 github.com/jfrog/froggit-go v1.3.2/go.mod h1:QPE1t+DTKgp7TxLQ1ZftDQVzkCHXAyYQskLGAKQe8yM=
 github.com/jfrog/gofrog v1.2.4 h1:PDk/TFUz6HFvXIdoVI4UFzeoVocMVIu+YkROKHJXCOY=
 github.com/jfrog/gofrog v1.2.4/go.mod h1:lbkGXX/DHKdomaSV34eiOC3pAr1HRNa9ffOYh7U7b1U=
+github.com/jfrog/jfrog-cli-core/v2 v2.24.0 h1:bGoJqkpGr6RxNpO/0+7ybPrpG4Q8ExNYrwXoSPfeANg=
+github.com/jfrog/jfrog-cli-core/v2 v2.24.0/go.mod h1:dtcFGR/ep+dBNzwJ9mf2YgI3d9+1sTbdU9HTmLeN4TE=
 github.com/jfrog/jfrog-client-go v1.24.2 h1:FjF6TQQs1VVnY/oYkWt3yR4aS0O9aQ37Te+j/QIu2hw=
 github.com/jfrog/jfrog-client-go v1.24.2/go.mod h1:cUi4SuJqQ7miwfRi9dnGaWiSGJoi7bVmuxZy+OJfXw4=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
@@ -322,8 +324,6 @@ github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PK
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/subosito/gotenv v1.3.0 h1:mjC+YW8QpAdXibNi+vNWgzmgBH4+5l5dCXv8cNysBLI=
 github.com/subosito/gotenv v1.3.0/go.mod h1:YzJjq/33h7nrwdY+iHMhEOEEbW0ovIz0tB6t6PwAXzs=
-github.com/sverdlov93/jfrog-cli-core/v2 v2.0.2-0.20221024142700-41015bd6517c h1:BUB8DWPVOe8ed1Qzqo3ILo85o2iWG2SWJsHa3qJMedA=
-github.com/sverdlov93/jfrog-cli-core/v2 v2.0.2-0.20221024142700-41015bd6517c/go.mod h1:xI66PKln++mWh+ablNWKHS/QzSkUrad7UbaYSba9los=
 github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/ulikunitz/xz v0.5.9 h1:RsKRIA2MO8x56wkkcd3LbtcE/uMszhb6DpRf+3uwa3I=
 github.com/ulikunitz/xz v0.5.9/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=

--- a/go.sum
+++ b/go.sum
@@ -211,14 +211,14 @@ github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i
 github.com/jedib0t/go-pretty/v6 v6.3.7 h1:H3Ulkf7h6A+p0HgKBGzgDn0bZIupRbKKWF4pO4Bs7iA=
 github.com/jedib0t/go-pretty/v6 v6.3.7/go.mod h1:MgmISkTWDSFu0xOqiZ0mKNntMQ2mDgOcwOkwBEkMDJI=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
-github.com/jfrog/build-info-go v1.8.0 h1:YqinllHwS8lscBOpvQ1+fxzRRYICrY54kwZs3ohj3Us=
-github.com/jfrog/build-info-go v1.8.0/go.mod h1:00yoQNP5tiZNdmw+4RtE8ZRJ4CeV0O/BJzkKwLDNQAM=
+github.com/jfrog/build-info-go v1.8.1 h1:HVq3pVMwb88Lidyg6kumDKOag/KpsmhzOHhGYLr43Ec=
+github.com/jfrog/build-info-go v1.8.1/go.mod h1:00yoQNP5tiZNdmw+4RtE8ZRJ4CeV0O/BJzkKwLDNQAM=
 github.com/jfrog/froggit-go v1.3.2 h1:fkzsI13vQkZZ2eZiN1Pyq+ZNxlJ4lLF/jZ/MuUx8uk0=
 github.com/jfrog/froggit-go v1.3.2/go.mod h1:QPE1t+DTKgp7TxLQ1ZftDQVzkCHXAyYQskLGAKQe8yM=
 github.com/jfrog/gofrog v1.2.4 h1:PDk/TFUz6HFvXIdoVI4UFzeoVocMVIu+YkROKHJXCOY=
 github.com/jfrog/gofrog v1.2.4/go.mod h1:lbkGXX/DHKdomaSV34eiOC3pAr1HRNa9ffOYh7U7b1U=
-github.com/jfrog/jfrog-client-go v1.24.1 h1:jodcNhGX0HESsRQIjyvSiLeGj+MXTuLN/hFnGbpASWs=
-github.com/jfrog/jfrog-client-go v1.24.1/go.mod h1:vqlL5kCA4YK/Xyo46SjiDFFvZNzmv7HwieOAwWW3268=
+github.com/jfrog/jfrog-client-go v1.24.2 h1:FjF6TQQs1VVnY/oYkWt3yR4aS0O9aQ37Te+j/QIu2hw=
+github.com/jfrog/jfrog-client-go v1.24.2/go.mod h1:cUi4SuJqQ7miwfRi9dnGaWiSGJoi7bVmuxZy+OJfXw4=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88/go.mod h1:3w7q1U84EfirKl04SVQ/s7nPm1ZPhiXd34z40TNz36k=
@@ -439,8 +439,6 @@ golang.org/x/net v0.0.0-20210326060303-6b1517762897/go.mod h1:uSPa2vr4CLtc/ILN5o
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
-golang.org/x/net v0.0.0-20220812174116-3211cb980234 h1:RDqmgfe7SvlMWoqC3xwQ2blLO3fcWcxMa3eBLRdRW7E=
-golang.org/x/net v0.0.0-20220812174116-3211cb980234/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/net v0.0.0-20220906165146-f3363e06e74c h1:yKufUcDwucU5urd+50/Opbt4AYpqthk7wHpHok8f1lo=
 golang.org/x/net v0.0.0-20220906165146-f3363e06e74c/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/oauth2 v0.0.0-20180227000427-d7d64896b5ff/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/frogbot#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.

---
-  In case of a scan response without vulnerabilities, send an empty sarif to the Github API. Performing this operation will 'reset' the Github Security Tab and close outdated security alerts.