### PR TITLE
Warn when code scanning upload fails

### DIFF
--- a/commands/createfixpullrequests.go
+++ b/commands/createfixpullrequests.go
@@ -42,7 +42,7 @@ func (cfp CreateFixPullRequestsCmd) Run(params *utils.FrogbotParams, client vcsc
 	// Upload scan results to the relevant Git provider code scanning UI
 	err = utils.UploadScanToGitProvider(scanResults, params, client)
 	if err != nil {
-		return err
+		clientLog.Warn(err)
 	}
 
 	// Fix and create PRs


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/frogbot#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.

---
- Warn when code scanning upload fails.
- Don't stop the creation of Frogbot Fix Pull Requests.
- Following https://github.com/jfrog/frogbot/issues/178