### PR TITLE
Reduce the Scan Repositories cron frequency to one hour

### DIFF
--- a/docs/install-azure-repos.md
+++ b/docs/install-azure-repos.md
@@ -34,8 +34,8 @@ To install Frogbot on Azure Repos repositories, follow these steps.
 
        ```yml
         schedules:
-             # Every 5 minutes
-             - cron: "*/5 * * * *"
+             # Run once an hour
+             - cron: "* */1 * * *"
                branches: 
                  include: 
                    - "*"

--- a/docs/install-bitbucket-server.md
+++ b/docs/install-bitbucket-server.md
@@ -34,8 +34,8 @@
    - Create a Pipeline job in Jenkins pointing to the Jenkinsfile in your **Frogbot Management Repository**.
 
    ```groovy
-   // Run the job every 5 minutes 
-   CRON_SETTINGS = '''*/5 * * * *'''
+   // Run the job once an hour 
+   CRON_SETTINGS = '''* */1 * * *'''
    
    pipeline {
        agent any

--- a/docs/install-github.md
+++ b/docs/install-github.md
@@ -72,8 +72,8 @@
           <summary>Template</summary>
 
    ```groovy
-   // Run the job every 5 minutes 
-   CRON_SETTINGS = '''*/5 * * * *'''
+   // Run the job once an hour 
+   CRON_SETTINGS = '''* */1 * * *'''
    pipeline {
        agent any
        triggers {

--- a/docs/templates/jfrog-pipelines/pipelines-dotnet.yml
+++ b/docs/templates/jfrog-pipelines/pipelines-dotnet.yml
@@ -2,7 +2,7 @@ resources:
   - name: cron_trigger
     type: CronTrigger
     configuration:
-      interval: '*/5 * * * *'     # Every 5 minutes
+      interval: '* */1 * * *'     # Run once an hour
 
   - name: frogbotGitRepo
     type: GitRepo

--- a/docs/templates/jfrog-pipelines/pipelines-go.yml
+++ b/docs/templates/jfrog-pipelines/pipelines-go.yml
@@ -2,7 +2,7 @@ resources:
   - name: cron_trigger
     type: CronTrigger
     configuration:
-      interval: '*/5 * * * *'     # Every 5 minutes
+      interval: '* */1 * * *'     # Run once an hour
 
   - name: frogbotGitRepo
     type: GitRepo

--- a/docs/templates/jfrog-pipelines/pipelines-gradle.yml
+++ b/docs/templates/jfrog-pipelines/pipelines-gradle.yml
@@ -2,7 +2,7 @@ resources:
   - name: cron_trigger
     type: CronTrigger
     configuration:
-      interval: '*/5 * * * *'     # Every 5 minutes
+      interval: '* */1 * * *'     # Run once an hour
 
   - name: frogbotGitRepo
     type: GitRepo

--- a/docs/templates/jfrog-pipelines/pipelines-maven.yml
+++ b/docs/templates/jfrog-pipelines/pipelines-maven.yml
@@ -2,7 +2,7 @@ resources:
   - name: cron_trigger
     type: CronTrigger
     configuration:
-      interval: '*/5 * * * *'     # Every 5 minutes
+      interval: '* */1 * * *'     # Run once an hour
 
   - name: frogbotGitRepo
     type: GitRepo

--- a/docs/templates/jfrog-pipelines/pipelines-npm.yml
+++ b/docs/templates/jfrog-pipelines/pipelines-npm.yml
@@ -2,7 +2,7 @@ resources:
   - name: cron_trigger
     type: CronTrigger
     configuration:
-      interval: '*/5 * * * *'     # Every 5 minutes
+      interval: '* */1 * * *'     # Run once an hour
 
   - name: frogbotGitRepo
     type: GitRepo

--- a/docs/templates/jfrog-pipelines/pipelines-pip.yml
+++ b/docs/templates/jfrog-pipelines/pipelines-pip.yml
@@ -2,7 +2,7 @@ resources:
   - name: cron_trigger
     type: CronTrigger
     configuration:
-      interval: '*/5 * * * *'     # Every 5 minutes
+      interval: '* */1 * * *'     # Run once an hour
 
   - name: frogbotGitRepo
     type: GitRepo

--- a/docs/templates/jfrog-pipelines/pipelines-pipenv.yml
+++ b/docs/templates/jfrog-pipelines/pipelines-pipenv.yml
@@ -2,7 +2,7 @@ resources:
   - name: cron_trigger
     type: CronTrigger
     configuration:
-      interval: '*/5 * * * *'     # Every 5 minutes
+      interval: '* */1 * * *'     # Run once an hour
 
   - name: frogbotGitRepo
     type: GitRepo

--- a/docs/templates/jfrog-pipelines/pipelines-poetry.yml
+++ b/docs/templates/jfrog-pipelines/pipelines-poetry.yml
@@ -2,7 +2,7 @@ resources:
   - name: cron_trigger
     type: CronTrigger
     configuration:
-      interval: '*/5 * * * *'     # Every 5 minutes
+      interval: '* */1 * * *'     # Run once an hour
 
   - name: frogbotGitRepo
     type: GitRepo

--- a/docs/templates/jfrog-pipelines/pipelines-yarn2.yml
+++ b/docs/templates/jfrog-pipelines/pipelines-yarn2.yml
@@ -2,7 +2,7 @@ resources:
   - name: cron_trigger
     type: CronTrigger
     configuration:
-      interval: '*/5 * * * *'     # Every 5 minutes
+      interval: '* */1 * * *'     # Run once an hour
 
   - name: frogbotGitRepo
     type: GitRepo


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/frogbot#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
---
The cron frequency in the Frogbot workflow templates is currently 5 minutes, which is way too high. This PR reduces the scan frequency to once an hour.  

