### PR TITLE
Fix remote repository URL in documentation

### DIFF
--- a/docs/install-azure-repos.md
+++ b/docs/install-azure-repos.md
@@ -76,7 +76,7 @@ To install Frogbot on Azure Repos repositories, follow these steps.
    
                   # [Optional]
                   # If the machine that runs Frogbot has no access to the internet, set the name of a remote repository 
-                  # in Artifactory, which proxies https://releases.jfrog.io/artifactory
+                  # in Artifactory, which proxies https://releases.jfrog.io
                   # The 'frogbot' executable and other tools it needs will be downloaded through this repository.
                   # JF_RELEASES_REPO: ""
    

--- a/docs/install-bitbucket-server.md
+++ b/docs/install-bitbucket-server.md
@@ -77,7 +77,7 @@
             
             // [Optional]
             // If the machine that runs Frogbot has no access to the internet, set the name of a remote repository 
-            // in Artifactory, which proxies https://releases.jfrog.io/artifactory
+            // in Artifactory, which proxies https://releases.jfrog.io
             // The 'frogbot' executable and other tools it needs will be downloaded through this repository.
             // JF_RELEASES_REPO= ""
             

--- a/docs/install-github.md
+++ b/docs/install-github.md
@@ -109,7 +109,7 @@
               
            // [Optional]
            // If the machine that runs Frogbot has no access to the internet, set the name of a remote repository 
-           // in Artifactory, which proxies https://releases.jfrog.io/artifactory
+           // in Artifactory, which proxies https://releases.jfrog.io
            // The 'frogbot' executable and other tools it needs will be downloaded through this repository.
            // JF_RELEASES_REPO= ""
 

--- a/docs/install-gitlab.md
+++ b/docs/install-gitlab.md
@@ -56,7 +56,7 @@ frogbot-scan:
 
     # [Optional]
     # If the machine that runs Frogbot has no access to the internet, set the name of a remote repository 
-    # in Artifactory, which proxies https://releases.jfrog.io/artifactory
+    # in Artifactory, which proxies https://releases.jfrog.io
     # The 'frogbot' executable and other tools it needs will be downloaded through this repository.
     # JF_RELEASES_REPO: ""
 

--- a/docs/templates/github-actions/scan-and-fix/frogbot-scan-and-fix-go.yml
+++ b/docs/templates/github-actions/scan-and-fix/frogbot-scan-and-fix-go.yml
@@ -50,7 +50,7 @@ jobs:
 
           # [Optional]
           # If the machine that runs Frogbot has no access to the internet, set the name of a remote repository
-          # in Artifactory, which proxies https://releases.jfrog.io/artifactory
+          # in Artifactory, which proxies https://releases.jfrog.io
           # The 'frogbot' executable and other tools it needs will be downloaded through this repository.
           # JF_RELEASES_REPO: ""
 

--- a/docs/templates/github-actions/scan-and-fix/frogbot-scan-and-fix-maven.yml
+++ b/docs/templates/github-actions/scan-and-fix/frogbot-scan-and-fix-maven.yml
@@ -51,7 +51,7 @@ jobs:
 
           # [Optional]
           # If the machine that runs Frogbot has no access to the internet, set the name of a remote repository
-          # in Artifactory, which proxies https://releases.jfrog.io/artifactory
+          # in Artifactory, which proxies https://releases.jfrog.io
           # The 'frogbot' executable and other tools it needs will be downloaded through this repository.
           # JF_RELEASES_REPO: ""
 

--- a/docs/templates/github-actions/scan-and-fix/frogbot-scan-and-fix-npm.yml
+++ b/docs/templates/github-actions/scan-and-fix/frogbot-scan-and-fix-npm.yml
@@ -50,7 +50,7 @@ jobs:
 
           # [Optional]
           # If the machine that runs Frogbot has no access to the internet, set the name of a remote repository
-          # in Artifactory, which proxies https://releases.jfrog.io/artifactory
+          # in Artifactory, which proxies https://releases.jfrog.io
           # The 'frogbot' executable and other tools it needs will be downloaded through this repository.
           # JF_RELEASES_REPO: ""
 

--- a/docs/templates/github-actions/scan-and-fix/frogbot-scan-and-fix-pip.yml
+++ b/docs/templates/github-actions/scan-and-fix/frogbot-scan-and-fix-pip.yml
@@ -50,7 +50,7 @@ jobs:
 
           # [Optional]
           # If the machine that runs Frogbot has no access to the internet, set the name of a remote repository
-          # in Artifactory, which proxies https://releases.jfrog.io/artifactory
+          # in Artifactory, which proxies https://releases.jfrog.io
           # The 'frogbot' executable and other tools it needs will be downloaded through this repository.
           # JF_RELEASES_REPO: ""
 

--- a/docs/templates/github-actions/scan-and-fix/frogbot-scan-and-fix-pipenv.yml
+++ b/docs/templates/github-actions/scan-and-fix/frogbot-scan-and-fix-pipenv.yml
@@ -53,7 +53,7 @@ jobs:
 
           # [Optional]
           # If the machine that runs Frogbot has no access to the internet, set the name of a remote repository
-          # in Artifactory, which proxies https://releases.jfrog.io/artifactory
+          # in Artifactory, which proxies https://releases.jfrog.io
           # The 'frogbot' executable and other tools it needs will be downloaded through this repository.
           # JF_RELEASES_REPO: ""
 

--- a/docs/templates/github-actions/scan-and-fix/frogbot-scan-and-fix-poetry.yml
+++ b/docs/templates/github-actions/scan-and-fix/frogbot-scan-and-fix-poetry.yml
@@ -52,7 +52,7 @@ jobs:
 
           # [Optional]
           # If the machine that runs Frogbot has no access to the internet, set the name of a remote repository
-          # in Artifactory, which proxies https://releases.jfrog.io/artifactory
+          # in Artifactory, which proxies https://releases.jfrog.io
           # The 'frogbot' executable and other tools it needs will be downloaded through this repository.
           # JF_RELEASES_REPO: ""
 

--- a/docs/templates/github-actions/scan-and-fix/frogbot-scan-and-fix-yarn.yml
+++ b/docs/templates/github-actions/scan-and-fix/frogbot-scan-and-fix-yarn.yml
@@ -50,7 +50,7 @@ jobs:
 
           # [Optional]
           # If the machine that runs Frogbot has no access to the internet, set the name of a remote repository
-          # in Artifactory, which proxies https://releases.jfrog.io/artifactory
+          # in Artifactory, which proxies https://releases.jfrog.io
           # The 'frogbot' executable and other tools it needs will be downloaded through this repository.
           # JF_RELEASES_REPO: ""
 

--- a/docs/templates/github-actions/scan-pull-request/frogbot-scan-pr-dotnet.yml
+++ b/docs/templates/github-actions/scan-pull-request/frogbot-scan-pr-dotnet.yml
@@ -49,7 +49,7 @@ jobs:
 
           # [Optional]
           # If the machine that runs Frogbot has no access to the internet, set the name of a remote repository
-          # in Artifactory, which proxies https://releases.jfrog.io/artifactory
+          # in Artifactory, which proxies https://releases.jfrog.io
           # The 'frogbot' executable and other tools it needs will be downloaded through this repository.
           # JF_RELEASES_REPO: ""
 

--- a/docs/templates/github-actions/scan-pull-request/frogbot-scan-pr-go.yml
+++ b/docs/templates/github-actions/scan-pull-request/frogbot-scan-pr-go.yml
@@ -50,7 +50,7 @@ jobs:
 
           # [Optional]
           # If the machine that runs Frogbot has no access to the internet, set the name of a remote repository
-          # in Artifactory, which proxies https://releases.jfrog.io/artifactory
+          # in Artifactory, which proxies https://releases.jfrog.io
           # The 'frogbot' executable and other tools it needs will be downloaded through this repository.
           # JF_RELEASES_REPO: ""
 

--- a/docs/templates/github-actions/scan-pull-request/frogbot-scan-pr-gradle.yml
+++ b/docs/templates/github-actions/scan-pull-request/frogbot-scan-pr-gradle.yml
@@ -54,7 +54,7 @@ jobs:
 
           # [Optional]
           # If the machine that runs Frogbot has no access to the internet, set the name of a remote repository
-          # in Artifactory, which proxies https://releases.jfrog.io/artifactory
+          # in Artifactory, which proxies https://releases.jfrog.io
           # The 'frogbot' executable and other tools it needs will be downloaded through this repository.
           # JF_RELEASES_REPO: ""
 

--- a/docs/templates/github-actions/scan-pull-request/frogbot-scan-pr-maven.yml
+++ b/docs/templates/github-actions/scan-pull-request/frogbot-scan-pr-maven.yml
@@ -51,7 +51,7 @@ jobs:
 
           # [Optional]
           # If the machine that runs Frogbot has no access to the internet, set the name of a remote repository
-          # in Artifactory, which proxies https://releases.jfrog.io/artifactory
+          # in Artifactory, which proxies https://releases.jfrog.io
           # The 'frogbot' executable and other tools it needs will be downloaded through this repository.
           # JF_RELEASES_REPO: ""
 

--- a/docs/templates/github-actions/scan-pull-request/frogbot-scan-pr-npm.yml
+++ b/docs/templates/github-actions/scan-pull-request/frogbot-scan-pr-npm.yml
@@ -50,7 +50,7 @@ jobs:
 
           # [Optional]
           # If the machine that runs Frogbot has no access to the internet, set the name of a remote repository
-          # in Artifactory, which proxies https://releases.jfrog.io/artifactory
+          # in Artifactory, which proxies https://releases.jfrog.io
           # The 'frogbot' executable and other tools it needs will be downloaded through this repository.
           # JF_RELEASES_REPO: ""
 

--- a/docs/templates/github-actions/scan-pull-request/frogbot-scan-pr-nuget.yml
+++ b/docs/templates/github-actions/scan-pull-request/frogbot-scan-pr-nuget.yml
@@ -49,7 +49,7 @@ jobs:
 
           # [Optional]
           # If the machine that runs Frogbot has no access to the internet, set the name of a remote repository
-          # in Artifactory, which proxies https://releases.jfrog.io/artifactory
+          # in Artifactory, which proxies https://releases.jfrog.io
           # The 'frogbot' executable and other tools it needs will be downloaded through this repository.
           # JF_RELEASES_REPO: ""
 

--- a/docs/templates/github-actions/scan-pull-request/frogbot-scan-pr-pip.yml
+++ b/docs/templates/github-actions/scan-pull-request/frogbot-scan-pr-pip.yml
@@ -49,7 +49,7 @@ jobs:
 
           # [Optional]
           # If the machine that runs Frogbot has no access to the internet, set the name of a remote repository
-          # in Artifactory, which proxies https://releases.jfrog.io/artifactory
+          # in Artifactory, which proxies https://releases.jfrog.io
           # The 'frogbot' executable and other tools it needs will be downloaded through this repository.
           # JF_RELEASES_REPO: ""
 

--- a/docs/templates/github-actions/scan-pull-request/frogbot-scan-pr-pipenv.yml
+++ b/docs/templates/github-actions/scan-pull-request/frogbot-scan-pr-pipenv.yml
@@ -51,7 +51,7 @@ jobs:
 
           # [Optional]
           # If the machine that runs Frogbot has no access to the internet, set the name of a remote repository
-          # in Artifactory, which proxies https://releases.jfrog.io/artifactory
+          # in Artifactory, which proxies https://releases.jfrog.io
           # The 'frogbot' executable and other tools it needs will be downloaded through this repository.
           # JF_RELEASES_REPO: ""
 

--- a/docs/templates/github-actions/scan-pull-request/frogbot-scan-pr-poetry.yml
+++ b/docs/templates/github-actions/scan-pull-request/frogbot-scan-pr-poetry.yml
@@ -51,7 +51,7 @@ jobs:
 
           # [Optional]
           # If the machine that runs Frogbot has no access to the internet, set the name of a remote repository
-          # in Artifactory, which proxies https://releases.jfrog.io/artifactory
+          # in Artifactory, which proxies https://releases.jfrog.io
           # The 'frogbot' executable and other tools it needs will be downloaded through this repository.
           # JF_RELEASES_REPO: ""
 

--- a/docs/templates/github-actions/scan-pull-request/frogbot-scan-pr-yarn.yml
+++ b/docs/templates/github-actions/scan-pull-request/frogbot-scan-pr-yarn.yml
@@ -50,7 +50,7 @@ jobs:
 
           # [Optional]
           # If the machine that runs Frogbot has no access to the internet, set the name of a remote repository
-          # in Artifactory, which proxies https://releases.jfrog.io/artifactory
+          # in Artifactory, which proxies https://releases.jfrog.io
           # The 'frogbot' executable and other tools it needs will be downloaded through this repository.
           # JF_RELEASES_REPO: ""
 

--- a/docs/templates/jfrog-pipelines/pipelines-dotnet.yml
+++ b/docs/templates/jfrog-pipelines/pipelines-dotnet.yml
@@ -74,7 +74,7 @@ pipelines:
 
           # [Optional]
           # If the machine that runs Frogbot has no access to the internet, set the name of a remote repository
-          # in Artifactory, which proxies https://releases.jfrog.io/artifactory
+          # in Artifactory, which proxies https://releases.jfrog.io
           # The 'frogbot' executable and other tools it needs will be downloaded through this repository.
           # JF_RELEASES_REPO: ""
 

--- a/docs/templates/jfrog-pipelines/pipelines-go.yml
+++ b/docs/templates/jfrog-pipelines/pipelines-go.yml
@@ -72,7 +72,7 @@ pipelines:
 
           # [Optional]
           # If the machine that runs Frogbot has no access to the internet, set the name of a remote repository
-          # in Artifactory, which proxies https://releases.jfrog.io/artifactory
+          # in Artifactory, which proxies https://releases.jfrog.io
           # The 'frogbot' executable and other tools it needs will be downloaded through this repository.
           # JF_RELEASES_REPO: ""
 

--- a/docs/templates/jfrog-pipelines/pipelines-gradle.yml
+++ b/docs/templates/jfrog-pipelines/pipelines-gradle.yml
@@ -72,7 +72,7 @@ pipelines:
 
           # [Optional]
           # If the machine that runs Frogbot has no access to the internet, set the name of a remote repository
-          # in Artifactory, which proxies https://releases.jfrog.io/artifactory
+          # in Artifactory, which proxies https://releases.jfrog.io
           # The 'frogbot' executable and other tools it needs will be downloaded through this repository.
           # JF_RELEASES_REPO: ""
 

--- a/docs/templates/jfrog-pipelines/pipelines-maven.yml
+++ b/docs/templates/jfrog-pipelines/pipelines-maven.yml
@@ -72,7 +72,7 @@ pipelines:
 
           # [Optional]
           # If the machine that runs Frogbot has no access to the internet, set the name of a remote repository
-          # in Artifactory, which proxies https://releases.jfrog.io/artifactory
+          # in Artifactory, which proxies https://releases.jfrog.io
           # The 'frogbot' executable and other tools it needs will be downloaded through this repository.
           # JF_RELEASES_REPO: ""
 

--- a/docs/templates/jfrog-pipelines/pipelines-npm.yml
+++ b/docs/templates/jfrog-pipelines/pipelines-npm.yml
@@ -76,7 +76,7 @@ pipelines:
 
           # [Optional]
           # If the machine that runs Frogbot has no access to the internet, set the name of a remote repository
-          # in Artifactory, which proxies https://releases.jfrog.io/artifactory
+          # in Artifactory, which proxies https://releases.jfrog.io
           # The 'frogbot' executable and other tools it needs will be downloaded through this repository.
           # JF_RELEASES_REPO: ""
 

--- a/docs/templates/jfrog-pipelines/pipelines-pip.yml
+++ b/docs/templates/jfrog-pipelines/pipelines-pip.yml
@@ -76,7 +76,7 @@ pipelines:
 
           # [Optional]
           # If the machine that runs Frogbot has no access to the internet, set the name of a remote repository
-          # in Artifactory, which proxies https://releases.jfrog.io/artifactory
+          # in Artifactory, which proxies https://releases.jfrog.io
           # The 'frogbot' executable and other tools it needs will be downloaded through this repository.
           # JF_RELEASES_REPO: ""
 

--- a/docs/templates/jfrog-pipelines/pipelines-pipenv.yml
+++ b/docs/templates/jfrog-pipelines/pipelines-pipenv.yml
@@ -72,7 +72,7 @@ pipelines:
 
           # [Optional]
           # If the machine that runs Frogbot has no access to the internet, set the name of a remote repository
-          # in Artifactory, which proxies https://releases.jfrog.io/artifactory
+          # in Artifactory, which proxies https://releases.jfrog.io
           # The 'frogbot' executable and other tools it needs will be downloaded through this repository.
           # JF_RELEASES_REPO: ""
 

--- a/docs/templates/jfrog-pipelines/pipelines-poetry.yml
+++ b/docs/templates/jfrog-pipelines/pipelines-poetry.yml
@@ -72,7 +72,7 @@ pipelines:
 
           # [Optional]
           # If the machine that runs Frogbot has no access to the internet, set the name of a remote repository
-          # in Artifactory, which proxies https://releases.jfrog.io/artifactory
+          # in Artifactory, which proxies https://releases.jfrog.io
           # The 'frogbot' executable and other tools it needs will be downloaded through this repository.
           # JF_RELEASES_REPO: ""
 

--- a/docs/templates/jfrog-pipelines/pipelines-yarn2.yml
+++ b/docs/templates/jfrog-pipelines/pipelines-yarn2.yml
@@ -76,7 +76,7 @@ pipelines:
 
           # [Optional]
           # If the machine that runs Frogbot has no access to the internet, set the name of a remote repository
-          # in Artifactory, which proxies https://releases.jfrog.io/artifactory
+          # in Artifactory, which proxies https://releases.jfrog.io
           # The 'frogbot' executable and other tools it needs will be downloaded through this repository.
           # JF_RELEASES_REPO: ""
 

--- a/starter-workflows/code-scanning/frogbot-scan-and-fix.yml
+++ b/starter-workflows/code-scanning/frogbot-scan-and-fix.yml
@@ -51,7 +51,7 @@ jobs:
 
           # [Optional]
           # If the machine that runs Frogbot has no access to the internet, set the name of a remote repository
-          # in Artifactory, which proxies https://releases.jfrog.io/artifactory
+          # in Artifactory, which proxies https://releases.jfrog.io
           # The 'frogbot' executable and other tools it needs will be downloaded through this repository.
           # JF_RELEASES_REPO: ""
 

--- a/starter-workflows/code-scanning/frogbot-scan-pr.yml
+++ b/starter-workflows/code-scanning/frogbot-scan-pr.yml
@@ -56,7 +56,7 @@ jobs:
 
           # [Optional]
           # If the machine that runs Frogbot has no access to the internet, set the name of a remote repository
-          # in Artifactory, which proxies https://releases.jfrog.io/artifactory
+          # in Artifactory, which proxies https://releases.jfrog.io
           # The 'frogbot' executable and other tools it needs will be downloaded through this repository.
           # JF_RELEASES_REPO: ""
 


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/frogbot#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
---
The documentation mistakenly states that the JF_RELEASES_REPO should reference `https://releases.jfrog.io/artifactory` while it should reference `https://releases.jfrog.io`.
