### PR TITLE
Allow overriding default scanning branch in scheduled workflows

### DIFF
--- a/.github/workflows/frogbot-scan-and-fix.yml
+++ b/.github/workflows/frogbot-scan-and-fix.yml
@@ -34,3 +34,8 @@ jobs:
           # [Mandatory]
           # The GitHub token automatically generated for the job
           JF_GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+          # [Optional]
+          # Specifies the branch to be scanned when this workflow is triggered by the schedule event.
+          # By default, it is set to the default branch defined in your repository.
+          # JF_CRON_TARGET_BRANCH: branch-name

--- a/commands/utils/consts.go
+++ b/commands/utils/consts.go
@@ -42,6 +42,8 @@ const (
 	GitRepoEnv      = "JF_GIT_REPO"
 	GitProjectEnv   = "JF_GIT_PROJECT"
 	GitUsernameEnv  = "JF_GIT_USERNAME"
+	// Allows overwriting default branch when running on a scheduled event
+	GitScheduledTargetBranch = "JF_CRON_TARGET_BRANCH"
 
 	// Git naming template environment variables
 	BranchNameTemplateEnv       = "JF_BRANCH_NAME_TEMPLATE"

--- a/commands/utils/params.go
+++ b/commands/utils/params.go
@@ -303,7 +303,15 @@ func extractGitParamsFromEnv() (*Git, error) {
 	if err = readParamFromEnv(GitBaseBranchEnv, &branch); err != nil && !e.IsMissingEnvErr(err) {
 		return nil, err
 	}
-	gitParams.Branches = append(gitParams.Branches, branch)
+	// When no branch is set, it will resolve to repository-defined default branch.
+	// This optionally allows overwriting the default branch that will be scanned on a scheduled events.
+	cronScanTargetBranch := getTrimmedEnv(GitScheduledTargetBranch)
+	if branch == "" && cronScanTargetBranch != "" {
+		gitParams.Branches = append(gitParams.Branches, cronScanTargetBranch)
+	} else {
+		gitParams.Branches = append(gitParams.Branches, branch)
+	}
+
 	if pullRequestIDString := getTrimmedEnv(GitPullRequestIDEnv); pullRequestIDString != "" {
 		gitParams.PullRequestID, err = strconv.Atoi(pullRequestIDString)
 		if err != nil {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/frogbot#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
---

When a workflow is triggered through a scheduled event, it does not include any branch information. As a result, the target branch defaults to the repository's default branch.

Default branch definition:
`The default branch is considered the “base” branch in your repository, against which all pull requests and code commits are automatically made, unless you specify a different branch.`

We need the ability to optionally specify a different target branch for cron scanning, overriding the default branch.

**Example:**
Assume the default branch is named "v2." However, during a scheduled run, we want Frogbot to open fix pull requests against the "dev" branch.

**Solution:**
To achieve this, set a new environment variable in the workflow: `JF_CRON_TARGET_BRANCH = "dev."` This will ensure that Frogbot targets the "dev" branch specifically during cron scanning.
