### PR TITLE
Use consistent aggregated branch name

### DIFF
--- a/commands/createfixpullrequests.go
+++ b/commands/createfixpullrequests.go
@@ -169,7 +169,7 @@ func (cfp *CreateFixPullRequestsCmd) fixIssuesSinglePR(fixVersionsMap map[string
 	var atLeastOneFix bool
 	log.Info("-----------------------------------------------------------------")
 	log.Info("Starting aggregated dependencies fix")
-	aggregatedFixBranchName, err := cfp.gitManager.GenerateAggregatedFixBranchName(fixVersionsMap)
+	aggregatedFixBranchName, err := cfp.gitManager.GenerateAggregatedFixBranchName()
 	if err != nil {
 		return
 	}

--- a/commands/utils/consts.go
+++ b/commands/utils/consts.go
@@ -97,7 +97,7 @@ const (
 
 	// Default naming templates
 	BranchNameTemplate                 = "frogbot-" + PackagePlaceHolder + "-" + BranchHashPlaceHolder
-	AggregatedBranchNameTemplate       = "frogobt-" + BranchHashPlaceHolder
+	AggregatedBranchNameTemplate       = "frogobt-Update-dependencies"
 	CommitMessageTemplate              = "Upgrade " + PackagePlaceHolder + " to " + FixVersionPlaceHolder
 	AggregatedPullRequestTitleTemplate = "[🐸 Frogbot] Update dependencies versions"
 	PullRequestTitleTemplate           = "[🐸 Frogbot] Update version of " + PackagePlaceHolder + " to " + FixVersionPlaceHolder

--- a/commands/utils/git.go
+++ b/commands/utils/git.go
@@ -320,17 +320,13 @@ func (gm *GitManager) GeneratePullRequestTitle(impactedPackage string, version s
 	return formatStringWithPlaceHolders(template, impactedPackage, version, "", true)
 }
 
-// Generates unique branch name constructed by all the vulnerable packages.
-func (gm *GitManager) GenerateAggregatedFixBranchName(versionsMap map[string]*FixDetails) (fixBranchName string, err error) {
-	hash, err := fixVersionsMapToMd5Hash(versionsMap)
-	if err != nil {
-		return
-	}
+// Generates consistent branch name to allow branch updates
+func (gm *GitManager) GenerateAggregatedFixBranchName() (fixBranchName string, err error) {
 	branchFormat := gm.customTemplates.branchNameTemplate
 	if branchFormat == "" {
-		branchFormat = AggregatedBranchNameTemplate
+		return AggregatedBranchNameTemplate, nil
 	}
-	return formatStringWithPlaceHolders(branchFormat, "", "", hash, false), nil
+	return formatStringWithPlaceHolders(branchFormat, "", "", "", false), nil
 }
 
 // dryRunClone clones an existing repository from our testdata folder into the destination folder for testing purposes.

--- a/commands/utils/git_test.go
+++ b/commands/utils/git_test.go
@@ -120,55 +120,35 @@ func TestGitManager_GeneratePullRequestTitle(t *testing.T) {
 
 func TestGitManager_GenerateAggregatedFixBranchName(t *testing.T) {
 	tests := []struct {
-		fixVersionMapFirst  map[string]*FixDetails
-		fixVersionMapSecond map[string]*FixDetails
-		gitManager          GitManager
-		equal               bool
-		desc                string
+		fixVersionMap map[string]*FixDetails
+		gitManager    GitManager
+		expected      string
+		desc          string
 	}{
 		{
-			fixVersionMapFirst: map[string]*FixDetails{
+			fixVersionMap: map[string]*FixDetails{
 				"pkg":  {FixVersion: "1.2.3", PackageType: coreutils.Npm, DirectDependency: false},
 				"pkg2": {FixVersion: "1.5.3", PackageType: coreutils.Npm, DirectDependency: false}},
-			fixVersionMapSecond: map[string]*FixDetails{
-				"pkg":  {FixVersion: "1.2.3", PackageType: coreutils.Npm, DirectDependency: false},
-				"pkg2": {FixVersion: "1.5.3", PackageType: coreutils.Npm, DirectDependency: false}},
-			equal: true, desc: "should be equal",
+
+			expected:   AggregatedBranchNameTemplate,
+			desc:       "No template",
 			gitManager: GitManager{},
 		},
 		{
-			fixVersionMapFirst: map[string]*FixDetails{
+			fixVersionMap: map[string]*FixDetails{
 				"pkg":  {FixVersion: "1.2.3", PackageType: coreutils.Npm, DirectDependency: false},
-				"pkg2": {FixVersion: "1.5.3", PackageType: coreutils.Npm, DirectDependency: false},
-			},
-			fixVersionMapSecond: map[string]*FixDetails{
-				"pkgOther": {FixVersion: "1.2.3", PackageType: coreutils.Npm, DirectDependency: false},
-				"pkg2":     {FixVersion: "1.5.3", PackageType: coreutils.Npm, DirectDependency: false}},
-			equal:      false,
-			desc:       "should not be equal",
-			gitManager: GitManager{},
-		},
-		{
-			fixVersionMapFirst: map[string]*FixDetails{
-				"pkg":  {FixVersion: "1.2.3", PackageType: coreutils.Npm, DirectDependency: false},
-				"pkg2": {FixVersion: "1.5.3", PackageType: coreutils.Npm, DirectDependency: false},
-			},
-			fixVersionMapSecond: map[string]*FixDetails{
-				"pkgOther": {FixVersion: "1.2.3", PackageType: coreutils.Npm, DirectDependency: false},
-				"pkg2":     {FixVersion: "1.5.3", PackageType: coreutils.Npm, DirectDependency: false}},
-			equal:      true,
-			desc:       "should be equal with template",
+				"pkg2": {FixVersion: "1.5.3", PackageType: coreutils.Npm, DirectDependency: false}},
+
+			expected:   "custom",
+			desc:       "No template",
 			gitManager: GitManager{customTemplates: CustomTemplates{branchNameTemplate: "custom"}},
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			titleOutput1, err := test.gitManager.GenerateAggregatedFixBranchName(test.fixVersionMapFirst)
+			titleOutput, err := test.gitManager.GenerateAggregatedFixBranchName()
 			assert.NoError(t, err)
-			titleOutput2, err := test.gitManager.GenerateAggregatedFixBranchName(test.fixVersionMapSecond)
-			assert.NoError(t, err)
-			equal := titleOutput1 == titleOutput2
-			assert.Equal(t, test.equal, equal)
+			assert.Equal(t, test.expected, titleOutput)
 		})
 	}
 }

--- a/commands/utils/utils.go
+++ b/commands/utils/utils.go
@@ -20,7 +20,6 @@ import (
 	"github.com/jfrog/jfrog-client-go/xray/services"
 	"os"
 	"regexp"
-	"sort"
 	"strings"
 )
 
@@ -166,24 +165,6 @@ func Md5Hash(values ...string) (string, error) {
 		}
 	}
 	return hex.EncodeToString(hash.Sum(nil)), nil
-}
-
-// Generates MD5Hash from a FixVersionMap object
-// The map can be returned in different order from Xray, so we need to sort the strings before hashing.
-func fixVersionsMapToMd5Hash(versionsMap map[string]*FixDetails) (string, error) {
-	h := crypto.MD5.New()
-	// Sort the package names
-	keys := make([]string, 0, len(versionsMap))
-	for k, v := range versionsMap {
-		keys = append(keys, k+v.FixVersion)
-	}
-	sort.Strings(keys)
-	for key, value := range keys {
-		if _, err := fmt.Fprint(h, key, value); err != nil {
-			return "", err
-		}
-	}
-	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
 // UploadScanToGitProvider uploads scan results to the relevant git provider in order to view the scan in the Git provider code scanning UI

--- a/commands/utils/utils_test.go
+++ b/commands/utils/utils_test.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"bytes"
 	"fmt"
-	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
 	"github.com/jfrog/jfrog-cli-core/v2/xray/formats"
 	"net/http"
 	"net/http/httptest"
@@ -128,43 +127,6 @@ func TestMd5Hash(t *testing.T) {
 		})
 	}
 }
-
-func TestFixVersionsMapToMd5Hash(t *testing.T) {
-	tests := []struct {
-		fixVersionMap map[string]*FixDetails
-		expectedHash  string
-	}{
-		{
-			fixVersionMap: map[string]*FixDetails{
-				"pkg": {FixVersion: "1.2.3", PackageType: coreutils.Npm, DirectDependency: false}},
-			expectedHash: "0aa066970b613b114f8e21d11c74ff94",
-		}, {
-			fixVersionMap: map[string]*FixDetails{
-				"pkg":  {FixVersion: "5.2.3", PackageType: coreutils.Go, DirectDependency: false},
-				"pkg2": {FixVersion: "1.2.3", PackageType: coreutils.Go, DirectDependency: false}},
-			expectedHash: "a0d4119dfe5fc5186d6c2cf1497f8c7c",
-		},
-		{
-			// The Same map with different order should be the same hash.
-			fixVersionMap: map[string]*FixDetails{
-				"pkg2": {FixVersion: "1.2.3", PackageType: coreutils.Go, DirectDependency: false},
-				"pkg":  {FixVersion: "5.2.3", PackageType: coreutils.Go, DirectDependency: false}},
-			expectedHash: "a0d4119dfe5fc5186d6c2cf1497f8c7c",
-		}, {
-			fixVersionMap: map[string]*FixDetails{
-				"myNuget": {FixVersion: "0.2.33", PackageType: coreutils.Nuget, DirectDependency: false}},
-			expectedHash: "887ac2c931920c20956409702c0dfbc7",
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.expectedHash, func(t *testing.T) {
-			hash, err := fixVersionsMapToMd5Hash(test.fixVersionMap)
-			assert.NoError(t, err)
-			assert.Equal(t, test.expectedHash, hash)
-		})
-	}
-}
-
 func TestGetRelativeWd(t *testing.T) {
 	fullPath := filepath.Join("a", "b", "c", "d", "e")
 	baseWd := filepath.Join("a", "b", "c")


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/frogbot#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
---

Up until now we generated aggregatedFixBranch name with hash generated from the scan results.

I suggest using to a consistent branch name that will update no mater what the scan results are, this will promise that when aggregate_fixes is set to true, that will be only one branch at any given time.