### PR TITLE
Fix version is not available in Maven

### DIFF
--- a/commands/utils/packagehandlers/mavenpackagehandler.go
+++ b/commands/utils/packagehandlers/mavenpackagehandler.go
@@ -269,7 +269,7 @@ func (mph *MavenPackageHandler) getProjectPoms() (err error) {
 // Update the package version. Updates it only if the version is not a reference to a property.
 func (mph *MavenPackageHandler) updatePackageVersion(impactedPackage, fixedVersion string, foundInDependencyManagement bool) (err error) {
 	updateVersionArgs := []string{
-		"-B", "org.codehaus.mojo:versions-maven-plugin:use-dep-version", "-Dincludes=" + impactedPackage,
+		"-U", "-B", "org.codehaus.mojo:versions-maven-plugin:use-dep-version", "-Dincludes=" + impactedPackage,
 		"-DdepVersion=" + fixedVersion, "-DgenerateBackupPoms=false",
 		fmt.Sprintf("-DprocessDependencies=%t", !foundInDependencyManagement),
 		fmt.Sprintf("-DprocessDependencyManagement=%t", foundInDependencyManagement)}
@@ -283,7 +283,7 @@ func (mph *MavenPackageHandler) updatePackageVersion(impactedPackage, fixedVersi
 func (mph *MavenPackageHandler) updateProperties(depDetails *pomDependencyDetails, fixedVersion string) error {
 	for _, property := range depDetails.properties {
 		updatePropertyArgs := []string{
-			"-B", "org.codehaus.mojo:versions-maven-plugin:set-property", "-Dproperty=" + property,
+			"-U", "-B", "org.codehaus.mojo:versions-maven-plugin:set-property", "-Dproperty=" + property,
 			"-DnewVersion=" + fixedVersion, "-DgenerateBackupPoms=false",
 			fmt.Sprintf("-DprocessDependencies=%t", !depDetails.foundInDependencyManagement),
 			fmt.Sprintf("-DprocessDependencyManagement=%t", depDetails.foundInDependencyManagement)}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/frogbot#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
---

Fix the following issue, caused by an outdated cache:
> 2023-06-21T03:33:00.748Z [main] ERROR org.apache.maven.cli.MavenCli - Failed to execute goal org.codehaus.mojo:versions-maven-plugin:2.16.0:use-dep-version (default-cli) on project artifactory-monorepo-dev: Version 7.5.1 is not available for artifact org.testng:testng -> [Help 1]

**To reproduce:**
1. Remove all versions above 7.5.0 in the following local files:
    * .m2/repository/org/testng/testng/maven-metadata-artifactory-release.xml
    * .m2/repository/org/testng/testng/maven-metadata-artifactory-snapshot.xml
    * .m2/repository/org/testng/testng/maven-metadata-central.xml

2. Run the following Maven command:
`mvn org.apache.maven.plugins:maven-dependency-plugin:get -Dartifact=org.testng:testng:6.6`
3. Add the `-U` flag to see that the issue is fixed:
`mvn -U org.apache.maven.plugins:maven-dependency-plugin:get -Dartifact=org.testng:testng:6.6`