### PR TITLE
Utilize default project when undefined in frogbot-config.yml

### DIFF
--- a/commands/testdata/config/frogbot-config-empty-scan.yml
+++ b/commands/testdata/config/frogbot-config-empty-scan.yml
@@ -1,0 +1,5 @@
+- params:
+    git:
+      repoName: clean-test-proj
+      branches:
+        - master

--- a/commands/utils/params.go
+++ b/commands/utils/params.go
@@ -137,6 +137,9 @@ func (s *Scan) setDefaultsIfNeeded() (err error) {
 	if s.MinSeverity, err = xrutils.GetSeveritiesFormat(s.MinSeverity); err != nil {
 		return
 	}
+	if len(s.Projects) == 0 {
+		s.Projects = append(s.Projects, Project{})
+	}
 	for i := range s.Projects {
 		if err = s.Projects[i].setDefaultsIfNeeded(); err != nil {
 			return

--- a/commands/utils/params_test.go
+++ b/commands/utils/params_test.go
@@ -191,6 +191,7 @@ func TestBuildRepoAggregatorWithEmptyScan(t *testing.T) {
 	configAggregator, err := BuildRepoAggregator(configFileContent, gitParams, server)
 	assert.NoError(t, err)
 	assert.Len(t, configAggregator, 1)
+	assert.False(t, configAggregator[0].AggregateFixes)
 	scan := configAggregator[0].Scan
 	assert.False(t, scan.IncludeAllVulnerabilities)
 	assert.False(t, scan.FixableOnly)

--- a/commands/utils/params_test.go
+++ b/commands/utils/params_test.go
@@ -11,7 +11,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var configParamsTestFile = filepath.Join("..", "testdata", "config", "frogbot-config-test-params.yml")
+var (
+	configParamsTestFile          = filepath.Join("..", "testdata", "config", "frogbot-config-test-params.yml")
+	configEmptyScanParamsTestFile = filepath.Join("..", "testdata", "config", "frogbot-config-empty-scan.yml")
+)
 
 func TestExtractParamsFromEnvError(t *testing.T) {
 	SetEnvAndAssert(t, map[string]string{
@@ -167,6 +170,42 @@ func TestExtractAndAssertRepoParams(t *testing.T) {
 			testExtractAndAssertProjectParams(t, project)
 		}
 	}
+}
+
+func TestBuildRepoAggregatorWithEmptyScan(t *testing.T) {
+	SetEnvAndAssert(t, map[string]string{
+		JFrogUrlEnv:     "http://127.0.0.1:8081",
+		JFrogTokenEnv:   "token",
+		GitProvider:     string(GitHub),
+		GitRepoOwnerEnv: "jfrog",
+		GitRepoEnv:      "frogbot",
+		GitTokenEnv:     "123456789",
+	})
+	defer func() {
+		assert.NoError(t, SanitizeEnv())
+	}()
+	server, gitParams, err := extractClientServerParams()
+	assert.NoError(t, err)
+	configFileContent, err := ReadConfigFromFileSystem(configEmptyScanParamsTestFile)
+	assert.NoError(t, err)
+	configAggregator, err := BuildRepoAggregator(configFileContent, gitParams, server)
+	assert.NoError(t, err)
+	assert.Len(t, configAggregator, 1)
+	scan := configAggregator[0].Scan
+	assert.False(t, scan.IncludeAllVulnerabilities)
+	assert.False(t, scan.FixableOnly)
+	assert.Empty(t, scan.MinSeverity)
+	assert.Empty(t, scan.JfrogReleasesRepo)
+	assert.True(t, *scan.FailOnSecurityIssues)
+	assert.Len(t, scan.Projects, 1)
+	project := scan.Projects[0]
+	assert.Empty(t, project.InstallCommandName)
+	assert.Empty(t, project.InstallCommandArgs)
+	assert.Empty(t, project.PipRequirementsFile)
+	assert.Empty(t, project.Repository)
+	assert.Len(t, project.WorkingDirs, 1)
+	assert.Equal(t, RootDir, project.WorkingDirs[0])
+	assert.True(t, *project.UseWrapper)
 }
 
 func testExtractAndAssertProjectParams(t *testing.T, project Project) {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/frogbot#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
---
- If the frogbot-config.yml file does not have the "Projects" field defined, create one with default values.