### PR TITLE
Fix identification of existing pull request on Bitbucket Server

### DIFF
--- a/commands/createfixpullrequests.go
+++ b/commands/createfixpullrequests.go
@@ -416,8 +416,6 @@ func (cfp *CreateFixPullRequestsCmd) getRemoteBranchScanHash(remoteBranchName st
 	return utils.VulnerabilityDetailsToMD5Hash(vulnerabilitiesMap)
 }
 
-// Retrieves the ID of an open pull request by source branch name.
-// Returns -1 if there is no open pull request.
 func (cfp *CreateFixPullRequestsCmd) getOpenPullRequestBySourceBranch(branchName string) (prInfo *vcsclient.PullRequestInfo, err error) {
 	list, err := cfp.details.Client().ListOpenPullRequests(context.Background(), cfp.details.RepoOwner, cfp.details.RepoName)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/go-git/go-git/v5 v5.7.0
 	github.com/golang/mock v1.6.0
 	github.com/jfrog/build-info-go v1.9.6
-	github.com/jfrog/froggit-go v1.8.0
+	github.com/jfrog/froggit-go v1.8.1
 	github.com/jfrog/gofrog v1.3.0
 	github.com/jfrog/jfrog-cli-core/v2 v2.36.0
 	github.com/jfrog/jfrog-client-go v1.30.1

--- a/go.sum
+++ b/go.sum
@@ -220,8 +220,8 @@ github.com/jedib0t/go-pretty/v6 v6.4.6 h1:v6aG9h6Uby3IusSSEjHaZNXpHFhzqMmjXcPq1R
 github.com/jedib0t/go-pretty/v6 v6.4.6/go.mod h1:Ndk3ase2CkQbXLLNf5QDHoYb6J9WtVfmHZu9n8rk2xs=
 github.com/jfrog/build-info-go v1.9.6 h1:lCJ2j5uXAlJsSwDe5J8WD7Co1f/hUlZvMfwfb5AzLJU=
 github.com/jfrog/build-info-go v1.9.6/go.mod h1:GbuFS+viHCKZYx9nWHYu7ab1DgQkFdtVN3BJPUNb2D4=
-github.com/jfrog/froggit-go v1.8.0 h1:pto08wTiPTF+B2JB9yI+fEA1A4D7cKq34p/7g8ZlTSU=
-github.com/jfrog/froggit-go v1.8.0/go.mod h1:XTFf4RqWwZsF9pdERt0Ra5gO1O3iqIq7Npx2tEQSGAQ=
+github.com/jfrog/froggit-go v1.8.1 h1:3eT1gQ7/Snft181Ig7EZlZSaXlr++tskdxgoCJKmAmw=
+github.com/jfrog/froggit-go v1.8.1/go.mod h1:XTFf4RqWwZsF9pdERt0Ra5gO1O3iqIq7Npx2tEQSGAQ=
 github.com/jfrog/gofrog v1.3.0 h1:o4zgsBZE4QyDbz2M7D4K6fXPTBJht+8lE87mS9bw7Gk=
 github.com/jfrog/gofrog v1.3.0/go.mod h1:IFMc+V/yf7rA5WZ74CSbXe+Lgf0iApEQLxRZVzKRUR0=
 github.com/jfrog/jfrog-cli-core/v2 v2.36.0 h1:SRS41DL34VkCZMxdIamQ/jUhM2lI72LGxLgLV+EouNs=


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/frogbot#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
---

Update Froggit-go with the bug fix on bitbucket server pull request response containing the entire ref instead of just the branch name