### PR TITLE
Update dependency errors ignored

### DIFF
--- a/commands/createfixpullrequests.go
+++ b/commands/createfixpullrequests.go
@@ -150,7 +150,7 @@ func (cfp *CreateFixPullRequestsCmd) fixIssuesSeparatePRs(vulnerabilitiesMap map
 	log.Info("-----------------------------------------------------------------")
 	for _, vulnDetails := range vulnerabilitiesMap {
 		if err = cfp.fixSinglePackageAndCreatePR(vulnDetails); err != nil {
-			cfp.handleUpdatePackageErrors(err, errList)
+			cfp.handleUpdatePackageErrors(err, &errList)
 		}
 		// After finishing to work on the current vulnerability, we go back to the base branch to start the next vulnerability fix
 		log.Debug("Running git checkout to base branch:", cfp.details.Branch())
@@ -195,7 +195,7 @@ func (cfp *CreateFixPullRequestsCmd) fixIssuesSinglePR(vulnerabilityDetails map[
 // Handles possible error of update package operation
 // When the expected custom error occurs, log to debug.
 // else, append to errList string.
-func (cfp *CreateFixPullRequestsCmd) handleUpdatePackageErrors(err error, errList strings.Builder) {
+func (cfp *CreateFixPullRequestsCmd) handleUpdatePackageErrors(err error, errList *strings.Builder) {
 	if _, isCustomError := err.(*utils.ErrUnsupportedFix); isCustomError {
 		log.Debug(err.Error())
 	} else {
@@ -443,7 +443,7 @@ func (cfp *CreateFixPullRequestsCmd) aggregateFixAndOpenPullRequest(vulnerabilit
 	var fixedVulnerabilities []formats.VulnerabilityOrViolationRow
 	for _, vulnDetails := range vulnerabilities {
 		if err = cfp.updatePackageToFixedVersion(vulnDetails); err != nil {
-			cfp.handleUpdatePackageErrors(err, errList)
+			cfp.handleUpdatePackageErrors(err, &errList)
 			// Clear the error after handling it.
 			err = nil
 		} else {

--- a/commands/createfixpullrequests_test.go
+++ b/commands/createfixpullrequests_test.go
@@ -2,7 +2,16 @@ package commands
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
 	"github.com/jfrog/frogbot/commands/utils"
 	"github.com/jfrog/froggit-go/vcsclient"
 	"github.com/jfrog/froggit-go/vcsutils"
@@ -14,13 +23,6 @@ import (
 	"github.com/jfrog/jfrog-client-go/xray/services"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"net/http/httptest"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"runtime"
-	"strings"
-	"testing"
 )
 
 const (
@@ -500,6 +502,18 @@ func TestUpdatePackageToFixedVersion(t *testing.T) {
 			assert.IsType(t, &utils.ErrUnsupportedFix{}, err, "Expected unsupported fix error")
 		}
 	}
+}
+
+func TestHandleUpdatePackageErrors(t *testing.T) {
+	var err = errors.New("Code Red")
+	cfp := CreateFixPullRequestsCmd{}
+	var errList strings.Builder
+	cfp.handleUpdatePackageErrors(err, &errList)
+	assert.Equal(t, err.Error()+"\n", errList.String())
+
+	errList.Reset()
+	cfp.handleUpdatePackageErrors(&utils.ErrUnsupportedFix{ErrorType: utils.BuildToolsDependencyFixNotSupported}, &errList)
+	assert.Empty(t, errList.String())
 }
 
 func verifyTechnologyNaming(t *testing.T, scanResponse []services.ScanResponse, expectedType coreutils.Technology) {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/frogbot#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
---

All errors in `updatePackageToFixedVersion` are ignored.
Explanation - `strings.Builder` is a struct and not an interface. To populate it inside a function we must provide a pointer.