### PR TITLE
Update to the workflows docs

### DIFF
--- a/.github/workflows/frogbot-scan-and-fix.yml
+++ b/.github/workflows/frogbot-scan-and-fix.yml
@@ -53,12 +53,20 @@ jobs:
           # JF_GIT_API_ENDPOINT: https://github.example.com
 
           # [Optional]
-          # If the machine that runs Frogbot has no access to the internet, set the name of a remote repository
-          # in Artifactory, which proxies https://releases.jfrog.io
-          # The 'frogbot' executable and other tools it needs will be downloaded through this repository.
+          # By default, the Frogbot workflows download the Frogbot executable as well as other tools
+          # needed from https://releases.jfrog.io
+          # If the machine that runs Frogbot has no access to the internet, follow these steps to allow the
+          # executable to be downloaded from an Artifactory instance, which the machine has access to:
+          #
+          # 1. Login to the Artifactory UI, with a user which has admin credentials.
+          # 2. Create a Remote Repository with the following properties set.
+          #    Under the 'Basic' tab:
+          #       Package Type: Generic
+          #       URL: https://releases.jfrog.io
+          #    Under the 'Advanced' tab:
+          #       Uncheck the 'Store Artifacts Locally' option
+          # 3. Set the value of the 'JF_RELEASES_REPO' variable with the Repository Key you created.
           # JF_RELEASES_REPO: ""
-
-
 
           ##########################################################################
           ##   If your project uses a 'frogbot-config.yml' file, you can define   ##

--- a/docs/install-azure-repos.md
+++ b/docs/install-azure-repos.md
@@ -82,9 +82,19 @@ To install Frogbot on Azure Repos repositories, follow these steps.
             JF_GIT_OWNER: ""
 
             # [Optional]
-            # If the machine that runs Frogbot has no access to the internet, set the name of a remote repository 
-            # in Artifactory, which proxies https://releases.jfrog.io
-            # The 'frogbot' executable and other tools it needs will be downloaded through this repository.
+            # By default, the Frogbot workflows download the Frogbot executable as well as other tools 
+            # needed from https://releases.jfrog.io
+            # If the machine that runs Frogbot has no access to the internet, follow these steps to allow the
+            # executable to be downloaded from an Artifactory instance, which the machine has access to: 
+            #
+            # 1. Login to the Artifactory UI, with a user which has admin credentials.
+            # 2. Create a Remote Repository with the following properties set.
+            #    Under the 'Basic' tab:
+            #       Package Type: Generic
+            #       URL: https://releases.jfrog.io
+            #    Under the 'Advanced' tab:
+            #       Uncheck the 'Store Artifacts Locally' option
+            # 3. Set the value of the 'JF_RELEASES_REPO' variable with the Repository Key you created.    
             # JF_RELEASES_REPO: ""
 
             ##########################################################################

--- a/docs/install-bitbucket-server.md
+++ b/docs/install-bitbucket-server.md
@@ -80,9 +80,19 @@
                JF_GIT_API_ENDPOINT= ""
                
                // [Optional]
-               // If the machine that runs Frogbot has no access to the internet, set the name of a remote repository 
-               // in Artifactory, which proxies https://releases.jfrog.io
-               // The 'frogbot' executable and other tools it needs will be downloaded through this repository.
+               // By default, the Frogbot workflows download the Frogbot executable as well as other tools 
+               // needed from https://releases.jfrog.io
+               // If the machine that runs Frogbot has no access to the internet, follow these steps to allow the
+               // executable to be downloaded from an Artifactory instance, which the machine has access to: 
+               //
+               // 1. Login to the Artifactory UI, with a user which has admin credentials.
+               // 2. Create a Remote Repository with the following properties set.
+               //    Under the 'Basic' tab:
+               //       Package Type: Generic
+               //       URL: https://releases.jfrog.io
+               //    Under the 'Advanced' tab:
+               //       Uncheck the 'Store Artifacts Locally' option
+               // 3. Set the value of the 'JF_RELEASES_REPO' variable with the Repository Key you created.
                // JF_RELEASES_REPO= ""
                
                ///////////////////////////////////////////////////////////////////////////

--- a/docs/install-github.md
+++ b/docs/install-github.md
@@ -108,9 +108,19 @@
           JF_GIT_API_ENDPOINT = ""
         
           // [Optional]
-          // If the machine that runs Frogbot has no access to the internet, set the name of a remote repository 
-          // in Artifactory, which proxies https://releases.jfrog.io
-          // The 'frogbot' executable and other tools it needs will be downloaded through this repository.
+          // By default, the Frogbot workflows download the Frogbot executable as well as other tools 
+          // needed from https://releases.jfrog.io
+          // If the machine that runs Frogbot has no access to the internet, follow these steps to allow the
+          // executable to be downloaded from an Artifactory instance, which the machine has access to: 
+          //
+          // 1. Login to the Artifactory UI, with a user which has admin credentials.
+          // 2. Create a Remote Repository with the following properties set.
+          //    Under the 'Basic' tab:
+          //       Package Type: Generic
+          //       URL: https://releases.jfrog.io
+          //    Under the 'Advanced' tab:
+          //       Uncheck the 'Store Artifacts Locally' option
+          // 3. Set the value of the 'JF_RELEASES_REPO' variable with the Repository Key you created.
           // JF_RELEASES_REPO= ""
 
           ///////////////////////////////////////////////////////////////////////////

--- a/docs/install-gitlab.md
+++ b/docs/install-gitlab.md
@@ -54,9 +54,19 @@ frogbot-scan:
     # JF_GIT_API_ENDPOINT: https://gitlab.example.com
 
     # [Optional]
-    # If the machine that runs Frogbot has no access to the internet, set the name of a remote repository 
-    # in Artifactory, which proxies https://releases.jfrog.io
-    # The 'frogbot' executable and other tools it needs will be downloaded through this repository.
+    # By default, the Frogbot workflows download the Frogbot executable as well as other tools 
+    # needed from https://releases.jfrog.io
+    # If the machine that runs Frogbot has no access to the internet, follow these steps to allow the
+    # executable to be downloaded from an Artifactory instance, which the machine has access to: 
+    #
+    # 1. Login to the Artifactory UI, with a user which has admin credentials.
+    # 2. Create a Remote Repository with the following properties set.
+    #    Under the 'Basic' tab:
+    #       Package Type: Generic
+    #       URL: https://releases.jfrog.io
+    #    Under the 'Advanced' tab:
+    #       Uncheck the 'Store Artifacts Locally' option
+    # 3. Set the value of the 'JF_RELEASES_REPO' variable with the Repository Key you created.
     # JF_RELEASES_REPO: ""
 
     ###########################################################################

--- a/docs/templates/github-actions/scan-and-fix/frogbot-scan-and-fix-go.yml
+++ b/docs/templates/github-actions/scan-and-fix/frogbot-scan-and-fix-go.yml
@@ -53,9 +53,19 @@ jobs:
           # JF_GIT_API_ENDPOINT: https://github.example.com
 
           # [Optional]
-          # If the machine that runs Frogbot has no access to the internet, set the name of a remote repository
-          # in Artifactory, which proxies https://releases.jfrog.io
-          # The 'frogbot' executable and other tools it needs will be downloaded through this repository.
+          # By default, the Frogbot workflows download the Frogbot executable as well as other tools
+          # needed from https://releases.jfrog.io
+          # If the machine that runs Frogbot has no access to the internet, follow these steps to allow the
+          # executable to be downloaded from an Artifactory instance, which the machine has access to:
+          #
+          # 1. Login to the Artifactory UI, with a user which has admin credentials.
+          # 2. Create a Remote Repository with the following properties set.
+          #    Under the 'Basic' tab:
+          #       Package Type: Generic
+          #       URL: https://releases.jfrog.io
+          #    Under the 'Advanced' tab:
+          #       Uncheck the 'Store Artifacts Locally' option
+          # 3. Set the value of the 'JF_RELEASES_REPO' variable with the Repository Key you created.
           # JF_RELEASES_REPO: ""
 
           ##########################################################################

--- a/docs/templates/github-actions/scan-and-fix/frogbot-scan-and-fix-maven.yml
+++ b/docs/templates/github-actions/scan-and-fix/frogbot-scan-and-fix-maven.yml
@@ -54,9 +54,19 @@ jobs:
           # JF_GIT_API_ENDPOINT: https://github.example.com
 
           # [Optional]
-          # If the machine that runs Frogbot has no access to the internet, set the name of a remote repository
-          # in Artifactory, which proxies https://releases.jfrog.io
-          # The 'frogbot' executable and other tools it needs will be downloaded through this repository.
+          # By default, the Frogbot workflows download the Frogbot executable as well as other tools
+          # needed from https://releases.jfrog.io
+          # If the machine that runs Frogbot has no access to the internet, follow these steps to allow the
+          # executable to be downloaded from an Artifactory instance, which the machine has access to:
+          #
+          # 1. Login to the Artifactory UI, with a user which has admin credentials.
+          # 2. Create a Remote Repository with the following properties set.
+          #    Under the 'Basic' tab:
+          #       Package Type: Generic
+          #       URL: https://releases.jfrog.io
+          #    Under the 'Advanced' tab:
+          #       Uncheck the 'Store Artifacts Locally' option
+          # 3. Set the value of the 'JF_RELEASES_REPO' variable with the Repository Key you created.
           # JF_RELEASES_REPO: ""
 
           ##########################################################################

--- a/docs/templates/github-actions/scan-and-fix/frogbot-scan-and-fix-npm.yml
+++ b/docs/templates/github-actions/scan-and-fix/frogbot-scan-and-fix-npm.yml
@@ -53,9 +53,19 @@ jobs:
           # JF_GIT_API_ENDPOINT: https://github.example.com
 
           # [Optional]
-          # If the machine that runs Frogbot has no access to the internet, set the name of a remote repository
-          # in Artifactory, which proxies https://releases.jfrog.io
-          # The 'frogbot' executable and other tools it needs will be downloaded through this repository.
+          # By default, the Frogbot workflows download the Frogbot executable as well as other tools
+          # needed from https://releases.jfrog.io
+          # If the machine that runs Frogbot has no access to the internet, follow these steps to allow the
+          # executable to be downloaded from an Artifactory instance, which the machine has access to:
+          #
+          # 1. Login to the Artifactory UI, with a user which has admin credentials.
+          # 2. Create a Remote Repository with the following properties set.
+          #    Under the 'Basic' tab:
+          #       Package Type: Generic
+          #       URL: https://releases.jfrog.io
+          #    Under the 'Advanced' tab:
+          #       Uncheck the 'Store Artifacts Locally' option
+          # 3. Set the value of the 'JF_RELEASES_REPO' variable with the Repository Key you created.
           # JF_RELEASES_REPO: ""
 
           ##########################################################################

--- a/docs/templates/github-actions/scan-and-fix/frogbot-scan-and-fix-pip.yml
+++ b/docs/templates/github-actions/scan-and-fix/frogbot-scan-and-fix-pip.yml
@@ -53,9 +53,19 @@ jobs:
           # JF_GIT_API_ENDPOINT: https://github.example.com
 
           # [Optional]
-          # If the machine that runs Frogbot has no access to the internet, set the name of a remote repository
-          # in Artifactory, which proxies https://releases.jfrog.io
-          # The 'frogbot' executable and other tools it needs will be downloaded through this repository.
+          # By default, the Frogbot workflows download the Frogbot executable as well as other tools
+          # needed from https://releases.jfrog.io
+          # If the machine that runs Frogbot has no access to the internet, follow these steps to allow the
+          # executable to be downloaded from an Artifactory instance, which the machine has access to:
+          #
+          # 1. Login to the Artifactory UI, with a user which has admin credentials.
+          # 2. Create a Remote Repository with the following properties set.
+          #    Under the 'Basic' tab:
+          #       Package Type: Generic
+          #       URL: https://releases.jfrog.io
+          #    Under the 'Advanced' tab:
+          #       Uncheck the 'Store Artifacts Locally' option
+          # 3. Set the value of the 'JF_RELEASES_REPO' variable with the Repository Key you created.
           # JF_RELEASES_REPO: ""
 
           ##########################################################################

--- a/docs/templates/github-actions/scan-and-fix/frogbot-scan-and-fix-pipenv.yml
+++ b/docs/templates/github-actions/scan-and-fix/frogbot-scan-and-fix-pipenv.yml
@@ -56,9 +56,19 @@ jobs:
           # JF_GIT_API_ENDPOINT: https://github.example.com
 
           # [Optional]
-          # If the machine that runs Frogbot has no access to the internet, set the name of a remote repository
-          # in Artifactory, which proxies https://releases.jfrog.io
-          # The 'frogbot' executable and other tools it needs will be downloaded through this repository.
+          # By default, the Frogbot workflows download the Frogbot executable as well as other tools
+          # needed from https://releases.jfrog.io
+          # If the machine that runs Frogbot has no access to the internet, follow these steps to allow the
+          # executable to be downloaded from an Artifactory instance, which the machine has access to:
+          #
+          # 1. Login to the Artifactory UI, with a user which has admin credentials.
+          # 2. Create a Remote Repository with the following properties set.
+          #    Under the 'Basic' tab:
+          #       Package Type: Generic
+          #       URL: https://releases.jfrog.io
+          #    Under the 'Advanced' tab:
+          #       Uncheck the 'Store Artifacts Locally' option
+          # 3. Set the value of the 'JF_RELEASES_REPO' variable with the Repository Key you created.
           # JF_RELEASES_REPO: ""
 
           ##########################################################################

--- a/docs/templates/github-actions/scan-and-fix/frogbot-scan-and-fix-poetry.yml
+++ b/docs/templates/github-actions/scan-and-fix/frogbot-scan-and-fix-poetry.yml
@@ -57,9 +57,19 @@ jobs:
           # JF_GIT_API_ENDPOINT: https://github.example.com
 
           # [Optional]
-          # If the machine that runs Frogbot has no access to the internet, set the name of a remote repository
-          # in Artifactory, which proxies https://releases.jfrog.io
-          # The 'frogbot' executable and other tools it needs will be downloaded through this repository.
+          # By default, the Frogbot workflows download the Frogbot executable as well as other tools
+          # needed from https://releases.jfrog.io
+          # If the machine that runs Frogbot has no access to the internet, follow these steps to allow the
+          # executable to be downloaded from an Artifactory instance, which the machine has access to:
+          #
+          # 1. Login to the Artifactory UI, with a user which has admin credentials.
+          # 2. Create a Remote Repository with the following properties set.
+          #    Under the 'Basic' tab:
+          #       Package Type: Generic
+          #       URL: https://releases.jfrog.io
+          #    Under the 'Advanced' tab:
+          #       Uncheck the 'Store Artifacts Locally' option
+          # 3. Set the value of the 'JF_RELEASES_REPO' variable with the Repository Key you created.
           # JF_RELEASES_REPO: ""
 
           ##########################################################################

--- a/docs/templates/github-actions/scan-and-fix/frogbot-scan-and-fix-yarn.yml
+++ b/docs/templates/github-actions/scan-and-fix/frogbot-scan-and-fix-yarn.yml
@@ -53,9 +53,19 @@ jobs:
           # JF_GIT_API_ENDPOINT: https://github.example.com
 
           # [Optional]
-          # If the machine that runs Frogbot has no access to the internet, set the name of a remote repository
-          # in Artifactory, which proxies https://releases.jfrog.io
-          # The 'frogbot' executable and other tools it needs will be downloaded through this repository.
+          # By default, the Frogbot workflows download the Frogbot executable as well as other tools
+          # needed from https://releases.jfrog.io
+          # If the machine that runs Frogbot has no access to the internet, follow these steps to allow the
+          # executable to be downloaded from an Artifactory instance, which the machine has access to:
+          #
+          # 1. Login to the Artifactory UI, with a user which has admin credentials.
+          # 2. Create a Remote Repository with the following properties set.
+          #    Under the 'Basic' tab:
+          #       Package Type: Generic
+          #       URL: https://releases.jfrog.io
+          #    Under the 'Advanced' tab:
+          #       Uncheck the 'Store Artifacts Locally' option
+          # 3. Set the value of the 'JF_RELEASES_REPO' variable with the Repository Key you created.
           # JF_RELEASES_REPO: ""
 
           ##########################################################################

--- a/docs/templates/github-actions/scan-pull-request/frogbot-scan-pr-dotnet.yml
+++ b/docs/templates/github-actions/scan-pull-request/frogbot-scan-pr-dotnet.yml
@@ -44,12 +44,20 @@ jobs:
           # JF_GIT_API_ENDPOINT: https://github.example.com
 
           # [Optional]
-          # If the machine that runs Frogbot has no access to the internet, set the name of a remote repository
-          # in Artifactory, which proxies https://releases.jfrog.io
-          # The 'frogbot' executable and other tools it needs will be downloaded through this repository.
+          # By default, the Frogbot workflows download the Frogbot executable as well as other tools
+          # needed from https://releases.jfrog.io
+          # If the machine that runs Frogbot has no access to the internet, follow these steps to allow the
+          # executable to be downloaded from an Artifactory instance, which the machine has access to:
+          #
+          # 1. Login to the Artifactory UI, with a user which has admin credentials.
+          # 2. Create a Remote Repository with the following properties set.
+          #    Under the 'Basic' tab:
+          #       Package Type: Generic
+          #       URL: https://releases.jfrog.io
+          #    Under the 'Advanced' tab:
+          #       Uncheck the 'Store Artifacts Locally' option
+          # 3. Set the value of the 'JF_RELEASES_REPO' variable with the Repository Key you created.
           # JF_RELEASES_REPO: ""
-
-
 
           ##########################################################################
           ##   If your project uses a 'frogbot-config.yml' file, you can define   ##

--- a/docs/templates/github-actions/scan-pull-request/frogbot-scan-pr-go.yml
+++ b/docs/templates/github-actions/scan-pull-request/frogbot-scan-pr-go.yml
@@ -45,12 +45,20 @@ jobs:
           # JF_GIT_API_ENDPOINT: https://github.example.com
 
           # [Optional]
-          # If the machine that runs Frogbot has no access to the internet, set the name of a remote repository
-          # in Artifactory, which proxies https://releases.jfrog.io
-          # The 'frogbot' executable and other tools it needs will be downloaded through this repository.
+          # By default, the Frogbot workflows download the Frogbot executable as well as other tools
+          # needed from https://releases.jfrog.io
+          # If the machine that runs Frogbot has no access to the internet, follow these steps to allow the
+          # executable to be downloaded from an Artifactory instance, which the machine has access to:
+          #
+          # 1. Login to the Artifactory UI, with a user which has admin credentials.
+          # 2. Create a Remote Repository with the following properties set.
+          #    Under the 'Basic' tab:
+          #       Package Type: Generic
+          #       URL: https://releases.jfrog.io
+          #    Under the 'Advanced' tab:
+          #       Uncheck the 'Store Artifacts Locally' option
+          # 3. Set the value of the 'JF_RELEASES_REPO' variable with the Repository Key you created.
           # JF_RELEASES_REPO: ""
-
-
 
           ##########################################################################
           ##   If your project uses a 'frogbot-config.yml' file, you can define   ##

--- a/docs/templates/github-actions/scan-pull-request/frogbot-scan-pr-gradle.yml
+++ b/docs/templates/github-actions/scan-pull-request/frogbot-scan-pr-gradle.yml
@@ -49,12 +49,20 @@ jobs:
           # JF_GIT_API_ENDPOINT: https://github.example.com
 
           # [Optional]
-          # If the machine that runs Frogbot has no access to the internet, set the name of a remote repository
-          # in Artifactory, which proxies https://releases.jfrog.io
-          # The 'frogbot' executable and other tools it needs will be downloaded through this repository.
+          # By default, the Frogbot workflows download the Frogbot executable as well as other tools
+          # needed from https://releases.jfrog.io
+          # If the machine that runs Frogbot has no access to the internet, follow these steps to allow the
+          # executable to be downloaded from an Artifactory instance, which the machine has access to:
+          #
+          # 1. Login to the Artifactory UI, with a user which has admin credentials.
+          # 2. Create a Remote Repository with the following properties set.
+          #    Under the 'Basic' tab:
+          #       Package Type: Generic
+          #       URL: https://releases.jfrog.io
+          #    Under the 'Advanced' tab:
+          #       Uncheck the 'Store Artifacts Locally' option
+          # 3. Set the value of the 'JF_RELEASES_REPO' variable with the Repository Key you created.
           # JF_RELEASES_REPO: ""
-
-
 
           ##########################################################################
           ##   If your project uses a 'frogbot-config.yml' file, you can define   ##

--- a/docs/templates/github-actions/scan-pull-request/frogbot-scan-pr-maven.yml
+++ b/docs/templates/github-actions/scan-pull-request/frogbot-scan-pr-maven.yml
@@ -46,12 +46,20 @@ jobs:
           # JF_GIT_API_ENDPOINT: https://github.example.com
 
           # [Optional]
-          # If the machine that runs Frogbot has no access to the internet, set the name of a remote repository
-          # in Artifactory, which proxies https://releases.jfrog.io
-          # The 'frogbot' executable and other tools it needs will be downloaded through this repository.
+          # By default, the Frogbot workflows download the Frogbot executable as well as other tools
+          # needed from https://releases.jfrog.io
+          # If the machine that runs Frogbot has no access to the internet, follow these steps to allow the
+          # executable to be downloaded from an Artifactory instance, which the machine has access to:
+          #
+          # 1. Login to the Artifactory UI, with a user which has admin credentials.
+          # 2. Create a Remote Repository with the following properties set.
+          #    Under the 'Basic' tab:
+          #       Package Type: Generic
+          #       URL: https://releases.jfrog.io
+          #    Under the 'Advanced' tab:
+          #       Uncheck the 'Store Artifacts Locally' option
+          # 3. Set the value of the 'JF_RELEASES_REPO' variable with the Repository Key you created.
           # JF_RELEASES_REPO: ""
-
-
 
           ##########################################################################
           ##   If your project uses a 'frogbot-config.yml' file, you can define   ##

--- a/docs/templates/github-actions/scan-pull-request/frogbot-scan-pr-npm.yml
+++ b/docs/templates/github-actions/scan-pull-request/frogbot-scan-pr-npm.yml
@@ -45,12 +45,20 @@ jobs:
           # JF_GIT_API_ENDPOINT: https://github.example.com
 
           # [Optional]
-          # If the machine that runs Frogbot has no access to the internet, set the name of a remote repository
-          # in Artifactory, which proxies https://releases.jfrog.io
-          # The 'frogbot' executable and other tools it needs will be downloaded through this repository.
+          # By default, the Frogbot workflows download the Frogbot executable as well as other tools
+          # needed from https://releases.jfrog.io
+          # If the machine that runs Frogbot has no access to the internet, follow these steps to allow the
+          # executable to be downloaded from an Artifactory instance, which the machine has access to:
+          #
+          # 1. Login to the Artifactory UI, with a user which has admin credentials.
+          # 2. Create a Remote Repository with the following properties set.
+          #    Under the 'Basic' tab:
+          #       Package Type: Generic
+          #       URL: https://releases.jfrog.io
+          #    Under the 'Advanced' tab:
+          #       Uncheck the 'Store Artifacts Locally' option
+          # 3. Set the value of the 'JF_RELEASES_REPO' variable with the Repository Key you created.
           # JF_RELEASES_REPO: ""
-
-
 
           ###########################################################################
           ##   If your project uses a 'frogbot-config.yml' file, you can define     ##

--- a/docs/templates/github-actions/scan-pull-request/frogbot-scan-pr-nuget.yml
+++ b/docs/templates/github-actions/scan-pull-request/frogbot-scan-pr-nuget.yml
@@ -44,12 +44,20 @@ jobs:
           JF_GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
           # [Optional]
-          # If the machine that runs Frogbot has no access to the internet, set the name of a remote repository
-          # in Artifactory, which proxies https://releases.jfrog.io
-          # The 'frogbot' executable and other tools it needs will be downloaded through this repository.
+          # By default, the Frogbot workflows download the Frogbot executable as well as other tools
+          # needed from https://releases.jfrog.io
+          # If the machine that runs Frogbot has no access to the internet, follow these steps to allow the
+          # executable to be downloaded from an Artifactory instance, which the machine has access to:
+          #
+          # 1. Login to the Artifactory UI, with a user which has admin credentials.
+          # 2. Create a Remote Repository with the following properties set.
+          #    Under the 'Basic' tab:
+          #       Package Type: Generic
+          #       URL: https://releases.jfrog.io
+          #    Under the 'Advanced' tab:
+          #       Uncheck the 'Store Artifacts Locally' option
+          # 3. Set the value of the 'JF_RELEASES_REPO' variable with the Repository Key you created.
           # JF_RELEASES_REPO: ""
-
-
 
           ##########################################################################
           ##   If your project uses a 'frogbot-config.yml' file, you can define   ##

--- a/docs/templates/github-actions/scan-pull-request/frogbot-scan-pr-pip.yml
+++ b/docs/templates/github-actions/scan-pull-request/frogbot-scan-pr-pip.yml
@@ -44,12 +44,20 @@ jobs:
           # JF_GIT_API_ENDPOINT: https://github.example.com
 
           # [Optional]
-          # If the machine that runs Frogbot has no access to the internet, set the name of a remote repository
-          # in Artifactory, which proxies https://releases.jfrog.io
-          # The 'frogbot' executable and other tools it needs will be downloaded through this repository.
+          # By default, the Frogbot workflows download the Frogbot executable as well as other tools
+          # needed from https://releases.jfrog.io
+          # If the machine that runs Frogbot has no access to the internet, follow these steps to allow the
+          # executable to be downloaded from an Artifactory instance, which the machine has access to:
+          #
+          # 1. Login to the Artifactory UI, with a user which has admin credentials.
+          # 2. Create a Remote Repository with the following properties set.
+          #    Under the 'Basic' tab:
+          #       Package Type: Generic
+          #       URL: https://releases.jfrog.io
+          #    Under the 'Advanced' tab:
+          #       Uncheck the 'Store Artifacts Locally' option
+          # 3. Set the value of the 'JF_RELEASES_REPO' variable with the Repository Key you created.
           # JF_RELEASES_REPO: ""
-
-
 
           ##########################################################################
           ##   If your project uses a 'frogbot-config.yml' file, you can define   ##

--- a/docs/templates/github-actions/scan-pull-request/frogbot-scan-pr-pipenv.yml
+++ b/docs/templates/github-actions/scan-pull-request/frogbot-scan-pr-pipenv.yml
@@ -46,12 +46,20 @@ jobs:
           # JF_GIT_API_ENDPOINT: https://github.example.com
 
           # [Optional]
-          # If the machine that runs Frogbot has no access to the internet, set the name of a remote repository
-          # in Artifactory, which proxies https://releases.jfrog.io
-          # The 'frogbot' executable and other tools it needs will be downloaded through this repository.
+          # By default, the Frogbot workflows download the Frogbot executable as well as other tools
+          # needed from https://releases.jfrog.io
+          # If the machine that runs Frogbot has no access to the internet, follow these steps to allow the
+          # executable to be downloaded from an Artifactory instance, which the machine has access to:
+          #
+          # 1. Login to the Artifactory UI, with a user which has admin credentials.
+          # 2. Create a Remote Repository with the following properties set.
+          #    Under the 'Basic' tab:
+          #       Package Type: Generic
+          #       URL: https://releases.jfrog.io
+          #    Under the 'Advanced' tab:
+          #       Uncheck the 'Store Artifacts Locally' option
+          # 3. Set the value of the 'JF_RELEASES_REPO' variable with the Repository Key you created.
           # JF_RELEASES_REPO: ""
-
-
 
           ##########################################################################
           ##   If your project uses a 'frogbot-config.yml' file, you can define   ##

--- a/docs/templates/github-actions/scan-pull-request/frogbot-scan-pr-poetry.yml
+++ b/docs/templates/github-actions/scan-pull-request/frogbot-scan-pr-poetry.yml
@@ -46,12 +46,20 @@ jobs:
           # JF_GIT_API_ENDPOINT: https://github.example.com
 
           # [Optional]
-          # If the machine that runs Frogbot has no access to the internet, set the name of a remote repository
-          # in Artifactory, which proxies https://releases.jfrog.io
-          # The 'frogbot' executable and other tools it needs will be downloaded through this repository.
+          # By default, the Frogbot workflows download the Frogbot executable as well as other tools
+          # needed from https://releases.jfrog.io
+          # If the machine that runs Frogbot has no access to the internet, follow these steps to allow the
+          # executable to be downloaded from an Artifactory instance, which the machine has access to:
+          #
+          # 1. Login to the Artifactory UI, with a user which has admin credentials.
+          # 2. Create a Remote Repository with the following properties set.
+          #    Under the 'Basic' tab:
+          #       Package Type: Generic
+          #       URL: https://releases.jfrog.io
+          #    Under the 'Advanced' tab:
+          #       Uncheck the 'Store Artifacts Locally' option
+          # 3. Set the value of the 'JF_RELEASES_REPO' variable with the Repository Key you created.
           # JF_RELEASES_REPO: ""
-
-
 
           ##########################################################################
           ##   If your project uses a 'frogbot-config.yml' file, you can define   ##

--- a/docs/templates/github-actions/scan-pull-request/frogbot-scan-pr-yarn.yml
+++ b/docs/templates/github-actions/scan-pull-request/frogbot-scan-pr-yarn.yml
@@ -45,12 +45,20 @@ jobs:
           # JF_GIT_API_ENDPOINT: https://github.example.com
 
           # [Optional]
-          # If the machine that runs Frogbot has no access to the internet, set the name of a remote repository
-          # in Artifactory, which proxies https://releases.jfrog.io
-          # The 'frogbot' executable and other tools it needs will be downloaded through this repository.
+          # By default, the Frogbot workflows download the Frogbot executable as well as other tools
+          # needed from https://releases.jfrog.io
+          # If the machine that runs Frogbot has no access to the internet, follow these steps to allow the
+          # executable to be downloaded from an Artifactory instance, which the machine has access to:
+          #
+          # 1. Login to the Artifactory UI, with a user which has admin credentials.
+          # 2. Create a Remote Repository with the following properties set.
+          #    Under the 'Basic' tab:
+          #       Package Type: Generic
+          #       URL: https://releases.jfrog.io
+          #    Under the 'Advanced' tab:
+          #       Uncheck the 'Store Artifacts Locally' option
+          # 3. Set the value of the 'JF_RELEASES_REPO' variable with the Repository Key you created.
           # JF_RELEASES_REPO: ""
-
-
 
           ##########################################################################
           ##   If your project uses a 'frogbot-config.yml' file, you can define   ##

--- a/docs/templates/jfrog-pipelines/pipelines-dotnet.yml
+++ b/docs/templates/jfrog-pipelines/pipelines-dotnet.yml
@@ -62,9 +62,19 @@ pipelines:
             JF_GIT_OWNER: ""
 
             # [Optional]
-            # If the machine that runs Frogbot has no access to the internet, set the name of a remote repository
-            # in Artifactory, which proxies https://releases.jfrog.io
-            # The 'frogbot' executable and other tools it needs will be downloaded through this repository.
+            # By default, the Frogbot workflows download the Frogbot executable as well as other tools
+            # needed from https://releases.jfrog.io
+            # If the machine that runs Frogbot has no access to the internet, follow these steps to allow the
+            # executable to be downloaded from an Artifactory instance, which the machine has access to:
+            #
+            # 1. Login to the Artifactory UI, with a user which has admin credentials.
+            # 2. Create a Remote Repository with the following properties set.
+            #    Under the 'Basic' tab:
+            #       Package Type: Generic
+            #       URL: https://releases.jfrog.io
+            #    Under the 'Advanced' tab:
+            #       Uncheck the 'Store Artifacts Locally' option
+            # 3. Set the value of the 'JF_RELEASES_REPO' variable with the Repository Key you created.
             # JF_RELEASES_REPO: ""
 
             ###########################################################################

--- a/docs/templates/jfrog-pipelines/pipelines-go.yml
+++ b/docs/templates/jfrog-pipelines/pipelines-go.yml
@@ -62,9 +62,19 @@ pipelines:
             JF_GIT_OWNER: ""
 
             # [Optional]
-            # If the machine that runs Frogbot has no access to the internet, set the name of a remote repository
-            # in Artifactory, which proxies https://releases.jfrog.io
-            # The 'frogbot' executable and other tools it needs will be downloaded through this repository.
+            # By default, the Frogbot workflows download the Frogbot executable as well as other tools
+            # needed from https://releases.jfrog.io
+            # If the machine that runs Frogbot has no access to the internet, follow these steps to allow the
+            # executable to be downloaded from an Artifactory instance, which the machine has access to:
+            #
+            # 1. Login to the Artifactory UI, with a user which has admin credentials.
+            # 2. Create a Remote Repository with the following properties set.
+            #    Under the 'Basic' tab:
+            #       Package Type: Generic
+            #       URL: https://releases.jfrog.io
+            #    Under the 'Advanced' tab:
+            #       Uncheck the 'Store Artifacts Locally' option
+            # 3. Set the value of the 'JF_RELEASES_REPO' variable with the Repository Key you created.
             # JF_RELEASES_REPO: ""
 
             ###########################################################################

--- a/docs/templates/jfrog-pipelines/pipelines-gradle.yml
+++ b/docs/templates/jfrog-pipelines/pipelines-gradle.yml
@@ -62,9 +62,19 @@ pipelines:
             JF_GIT_OWNER: ""
 
             # [Optional]
-            # If the machine that runs Frogbot has no access to the internet, set the name of a remote repository
-            # in Artifactory, which proxies https://releases.jfrog.io
-            # The 'frogbot' executable and other tools it needs will be downloaded through this repository.
+            # By default, the Frogbot workflows download the Frogbot executable as well as other tools
+            # needed from https://releases.jfrog.io
+            # If the machine that runs Frogbot has no access to the internet, follow these steps to allow the
+            # executable to be downloaded from an Artifactory instance, which the machine has access to:
+            #
+            # 1. Login to the Artifactory UI, with a user which has admin credentials.
+            # 2. Create a Remote Repository with the following properties set.
+            #    Under the 'Basic' tab:
+            #       Package Type: Generic
+            #       URL: https://releases.jfrog.io
+            #    Under the 'Advanced' tab:
+            #       Uncheck the 'Store Artifacts Locally' option
+            # 3. Set the value of the 'JF_RELEASES_REPO' variable with the Repository Key you created.
             # JF_RELEASES_REPO: ""
 
             ###########################################################################

--- a/docs/templates/jfrog-pipelines/pipelines-maven.yml
+++ b/docs/templates/jfrog-pipelines/pipelines-maven.yml
@@ -62,9 +62,19 @@ pipelines:
             JF_GIT_OWNER: ""
 
             # [Optional]
-            # If the machine that runs Frogbot has no access to the internet, set the name of a remote repository
-            # in Artifactory, which proxies https://releases.jfrog.io
-            # The 'frogbot' executable and other tools it needs will be downloaded through this repository.
+            # By default, the Frogbot workflows download the Frogbot executable as well as other tools
+            # needed from https://releases.jfrog.io
+            # If the machine that runs Frogbot has no access to the internet, follow these steps to allow the
+            # executable to be downloaded from an Artifactory instance, which the machine has access to:
+            #
+            # 1. Login to the Artifactory UI, with a user which has admin credentials.
+            # 2. Create a Remote Repository with the following properties set.
+            #    Under the 'Basic' tab:
+            #       Package Type: Generic
+            #       URL: https://releases.jfrog.io
+            #    Under the 'Advanced' tab:
+            #       Uncheck the 'Store Artifacts Locally' option
+            # 3. Set the value of the 'JF_RELEASES_REPO' variable with the Repository Key you created.
             # JF_RELEASES_REPO: ""
 
             ###########################################################################

--- a/docs/templates/jfrog-pipelines/pipelines-npm.yml
+++ b/docs/templates/jfrog-pipelines/pipelines-npm.yml
@@ -62,9 +62,19 @@ pipelines:
             JF_GIT_OWNER: ""
 
             # [Optional]
-            # If the machine that runs Frogbot has no access to the internet, set the name of a remote repository
-            # in Artifactory, which proxies https://releases.jfrog.io
-            # The 'frogbot' executable and other tools it needs will be downloaded through this repository.
+            # By default, the Frogbot workflows download the Frogbot executable as well as other tools
+            # needed from https://releases.jfrog.io
+            # If the machine that runs Frogbot has no access to the internet, follow these steps to allow the
+            # executable to be downloaded from an Artifactory instance, which the machine has access to:
+            #
+            # 1. Login to the Artifactory UI, with a user which has admin credentials.
+            # 2. Create a Remote Repository with the following properties set.
+            #    Under the 'Basic' tab:
+            #       Package Type: Generic
+            #       URL: https://releases.jfrog.io
+            #    Under the 'Advanced' tab:
+            #       Uncheck the 'Store Artifacts Locally' option
+            # 3. Set the value of the 'JF_RELEASES_REPO' variable with the Repository Key you created.
             # JF_RELEASES_REPO: ""
 
             ###########################################################################

--- a/docs/templates/jfrog-pipelines/pipelines-pip.yml
+++ b/docs/templates/jfrog-pipelines/pipelines-pip.yml
@@ -69,9 +69,19 @@ pipelines:
             JF_GIT_OWNER: ""
 
             # [Optional]
-            # If the machine that runs Frogbot has no access to the internet, set the name of a remote repository
-            # in Artifactory, which proxies https://releases.jfrog.io
-            # The 'frogbot' executable and other tools it needs will be downloaded through this repository.
+            # By default, the Frogbot workflows download the Frogbot executable as well as other tools
+            # needed from https://releases.jfrog.io
+            # If the machine that runs Frogbot has no access to the internet, follow these steps to allow the
+            # executable to be downloaded from an Artifactory instance, which the machine has access to:
+            #
+            # 1. Login to the Artifactory UI, with a user which has admin credentials.
+            # 2. Create a Remote Repository with the following properties set.
+            #    Under the 'Basic' tab:
+            #       Package Type: Generic
+            #       URL: https://releases.jfrog.io
+            #    Under the 'Advanced' tab:
+            #       Uncheck the 'Store Artifacts Locally' option
+            # 3. Set the value of the 'JF_RELEASES_REPO' variable with the Repository Key you created.
             # JF_RELEASES_REPO: ""
 
             ###########################################################################

--- a/docs/templates/jfrog-pipelines/pipelines-pipenv.yml
+++ b/docs/templates/jfrog-pipelines/pipelines-pipenv.yml
@@ -62,9 +62,19 @@ pipelines:
             JF_GIT_OWNER: ""
 
             # [Optional]
-            # If the machine that runs Frogbot has no access to the internet, set the name of a remote repository
-            # in Artifactory, which proxies https://releases.jfrog.io
-            # The 'frogbot' executable and other tools it needs will be downloaded through this repository.
+            # By default, the Frogbot workflows download the Frogbot executable as well as other tools
+            # needed from https://releases.jfrog.io
+            # If the machine that runs Frogbot has no access to the internet, follow these steps to allow the
+            # executable to be downloaded from an Artifactory instance, which the machine has access to:
+            #
+            # 1. Login to the Artifactory UI, with a user which has admin credentials.
+            # 2. Create a Remote Repository with the following properties set.
+            #    Under the 'Basic' tab:
+            #       Package Type: Generic
+            #       URL: https://releases.jfrog.io
+            #    Under the 'Advanced' tab:
+            #       Uncheck the 'Store Artifacts Locally' option
+            # 3. Set the value of the 'JF_RELEASES_REPO' variable with the Repository Key you created.
             # JF_RELEASES_REPO: ""
 
             ###########################################################################

--- a/docs/templates/jfrog-pipelines/pipelines-poetry.yml
+++ b/docs/templates/jfrog-pipelines/pipelines-poetry.yml
@@ -62,9 +62,19 @@ pipelines:
             JF_GIT_OWNER: ""
 
             # [Optional]
-            # If the machine that runs Frogbot has no access to the internet, set the name of a remote repository
-            # in Artifactory, which proxies https://releases.jfrog.io
-            # The 'frogbot' executable and other tools it needs will be downloaded through this repository.
+            # By default, the Frogbot workflows download the Frogbot executable as well as other tools
+            # needed from https://releases.jfrog.io
+            # If the machine that runs Frogbot has no access to the internet, follow these steps to allow the
+            # executable to be downloaded from an Artifactory instance, which the machine has access to:
+            #
+            # 1. Login to the Artifactory UI, with a user which has admin credentials.
+            # 2. Create a Remote Repository with the following properties set.
+            #    Under the 'Basic' tab:
+            #       Package Type: Generic
+            #       URL: https://releases.jfrog.io
+            #    Under the 'Advanced' tab:
+            #       Uncheck the 'Store Artifacts Locally' option
+            # 3. Set the value of the 'JF_RELEASES_REPO' variable with the Repository Key you created.
             # JF_RELEASES_REPO: ""
 
             ###########################################################################

--- a/docs/templates/jfrog-pipelines/pipelines-yarn2.yml
+++ b/docs/templates/jfrog-pipelines/pipelines-yarn2.yml
@@ -69,9 +69,19 @@ pipelines:
             JF_GIT_OWNER: ""
 
             # [Optional]
-            # If the machine that runs Frogbot has no access to the internet, set the name of a remote repository
-            # in Artifactory, which proxies https://releases.jfrog.io
-            # The 'frogbot' executable and other tools it needs will be downloaded through this repository.
+            # By default, the Frogbot workflows download the Frogbot executable as well as other tools
+            # needed from https://releases.jfrog.io
+            # If the machine that runs Frogbot has no access to the internet, follow these steps to allow the
+            # executable to be downloaded from an Artifactory instance, which the machine has access to:
+            #
+            # 1. Login to the Artifactory UI, with a user which has admin credentials.
+            # 2. Create a Remote Repository with the following properties set.
+            #    Under the 'Basic' tab:
+            #       Package Type: Generic
+            #       URL: https://releases.jfrog.io
+            #    Under the 'Advanced' tab:
+            #       Uncheck the 'Store Artifacts Locally' option
+            # 3. Set the value of the 'JF_RELEASES_REPO' variable with the Repository Key you created.
             # JF_RELEASES_REPO: ""
 
             ###########################################################################

--- a/starter-workflows/code-scanning/frogbot-scan-and-fix.yml
+++ b/starter-workflows/code-scanning/frogbot-scan-and-fix.yml
@@ -57,9 +57,19 @@ jobs:
           JF_GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
           # [Optional]
-          # If the machine that runs Frogbot has no access to the internet, set the name of a remote repository
-          # in Artifactory, which proxies https://releases.jfrog.io
-          # The 'frogbot' executable and other tools it needs will be downloaded through this repository.
+          # By default, the Frogbot workflows download the Frogbot executable as well as other tools
+          # needed from https://releases.jfrog.io
+          # If the machine that runs Frogbot has no access to the internet, follow these steps to allow the
+          # executable to be downloaded from an Artifactory instance, which the machine has access to:
+          #
+          # 1. Login to the Artifactory UI, with a user which has admin credentials.
+          # 2. Create a Remote Repository with the following properties set.
+          #    Under the 'Basic' tab:
+          #       Package Type: Generic
+          #       URL: https://releases.jfrog.io
+          #    Under the 'Advanced' tab:
+          #       Uncheck the 'Store Artifacts Locally' option
+          # 3. Set the value of the 'JF_RELEASES_REPO' variable with the Repository Key you created.
           # JF_RELEASES_REPO: ""
 
           ##########################################################################

--- a/starter-workflows/code-scanning/frogbot-scan-pr.yml
+++ b/starter-workflows/code-scanning/frogbot-scan-pr.yml
@@ -51,12 +51,20 @@ jobs:
           JF_GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
           # [Optional]
-          # If the machine that runs Frogbot has no access to the internet, set the name of a remote repository
-          # in Artifactory, which proxies https://releases.jfrog.io
-          # The 'frogbot' executable and other tools it needs will be downloaded through this repository.
+          # By default, the Frogbot workflows download the Frogbot executable as well as other tools
+          # needed from https://releases.jfrog.io
+          # If the machine that runs Frogbot has no access to the internet, follow these steps to allow the
+          # executable to be downloaded from an Artifactory instance, which the machine has access to:
+          #
+          # 1. Login to the Artifactory UI, with a user which has admin credentials.
+          # 2. Create a Remote Repository with the following properties set.
+          #    Under the 'Basic' tab:
+          #       Package Type: Generic
+          #       URL: https://releases.jfrog.io
+          #    Under the 'Advanced' tab:
+          #       Uncheck the 'Store Artifacts Locally' option
+          # 3. Set the value of the 'JF_RELEASES_REPO' variable with the Repository Key you created.
           # JF_RELEASES_REPO: ""
-
-
 
           #######################################################################
           ##   If you project uses a 'frogbot-config.yml' file, you can define    ##


### PR DESCRIPTION
Update to the description of the `JF_RELEASES_REPO` variable in the Frogbot workflows.
The goal of this update is to ensure that the 'Store Artifacts Locally' option isn't checked when defining the Remote Repository. When this option is checked, new version of Frogbot will not be downloaded through Remote Repository. Instead, an older version will be downloaded.