### PR TITLE
Separate env params extraction by context

### DIFF
--- a/commands/utils/params.go
+++ b/commands/utils/params.go
@@ -214,7 +214,8 @@ func (g *Git) setDefaultsIfNeeded(gitParamsFromEnv *Git) (err error) {
 		}
 	}
 	// When pull request ID is provided, no need to continue and extract unrelated env params.
-	if g.PullRequestDetails.ID != 0 || gitParamsFromEnv.PullRequestDetails.ID != 0 {
+	isPullRequestContext := gitParamsFromEnv.PullRequestDetails.ID != 0
+	if isPullRequestContext {
 		return
 	}
 	// Continue to extract ScanRepository related env params

--- a/go.sum
+++ b/go.sum
@@ -1222,7 +1222,6 @@ golang.org/x/net v0.7.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
 golang.org/x/net v0.8.0/go.mod h1:QVkue5JL9kW//ek3r6jTKnTFis1tRmNAW2P1shuFdJc=
 golang.org/x/net v0.9.0/go.mod h1:d48xBJpPfHeWQsugry2m+kC02ZBRGRgulfHnEXEuWns=
 golang.org/x/net v0.10.0/go.mod h1:0qNGK6F8kojg2nk9dLZ2mShWaEBan6FAoqfSigmmuDg=
-golang.org/x/net v0.12.0 h1:cfawfvKITfUsFCeJIHJrbSxpeu/E81khclypR0GVT50=
 golang.org/x/net v0.12.0/go.mod h1:zEVYFnQC7m/vmpQFELhcD1EWkZlX69l4oqgmer6hfKA=
 golang.org/x/net v0.13.0 h1:Nvo8UFsZ8X3BhAC9699Z1j7XQ3rsZnUUm7jfBEk1ueY=
 golang.org/x/net v0.13.0/go.mod h1:zEVYFnQC7m/vmpQFELhcD1EWkZlX69l4oqgmer6hfKA=


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/frogbot#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
---
Bug description:
ScanRepository params validation interfere with ScanPullRequest command while trying to get branches related params.

Fix:
**Env params extraction should behave different depending on command context.**
We assume the context of the command by the pull request ID param. If it is set, we assume we are in ScanPullRequest context, otherwise we are in ScanRepository context.

When in the context of ScanPullRequest, no need to extract branches related env vars.
In the context of ScanRepository, extract branches, git templates and aggregate fixes flag, which are all unrelated to the second context.