### PR TITLE
Enforce  mandatory JF_GIT_REPO param

### DIFF
--- a/utils/params.go
+++ b/utils/params.go
@@ -427,11 +427,6 @@ func extractGitParamsFromEnvs() (*Git, error) {
 	if branch != "" {
 		gitEnvParams.Branches = []string{branch}
 	}
-	// Set the repository name, mandatory.
-	if err = readParamFromEnv(GitRepoEnv, &gitEnvParams.RepoName); err != nil {
-		return nil, err
-	}
-
 	// Non-mandatory Git Api Endpoint, if not set, default values will be used.
 	if err = readParamFromEnv(GitApiEndpointEnv, &gitEnvParams.APIEndpoint); err != nil && !e.IsMissingEnvErr(err) {
 		return nil, err
@@ -439,16 +434,21 @@ func extractGitParamsFromEnvs() (*Git, error) {
 	if err = verifyValidApiEndpoint(gitEnvParams.APIEndpoint); err != nil {
 		return nil, err
 	}
-	// Set the Git provider
+	// [Mandatory] Set the Git provider
 	if gitEnvParams.GitProvider, err = extractVcsProviderFromEnv(); err != nil {
 		return nil, err
 	}
-	// Set the git repository owner name (organization)
+	// [Mandatory] Set the git repository owner name (organization)
 	if err = readParamFromEnv(GitRepoOwnerEnv, &gitEnvParams.RepoOwner); err != nil {
 		return nil, err
 	}
-	// Set the access token to the git provider
+	// [Mandatory] Set the access token to the git provider
 	if err = readParamFromEnv(GitTokenEnv, &gitEnvParams.Token); err != nil {
+		return nil, err
+	}
+
+	// [Mandatory] Set the repository name
+	if err = readParamFromEnv(GitRepoEnv, &gitEnvParams.RepoName); err != nil {
 		return nil, err
 	}
 

--- a/utils/params.go
+++ b/utils/params.go
@@ -427,8 +427,8 @@ func extractGitParamsFromEnvs() (*Git, error) {
 	if branch != "" {
 		gitEnvParams.Branches = []string{branch}
 	}
-	// Set the repository name
-	if err = readParamFromEnv(GitRepoEnv, &gitEnvParams.RepoName); err != nil && !e.IsMissingEnvErr(err) {
+	// Set the repository name, mandatory.
+	if err = readParamFromEnv(GitRepoEnv, &gitEnvParams.RepoName); err != nil {
 		return nil, err
 	}
 

--- a/utils/params_test.go
+++ b/utils/params_test.go
@@ -143,6 +143,10 @@ func TestExtractClientInfo(t *testing.T) {
 	SetEnvAndAssert(t, map[string]string{GitRepoOwnerEnv: "jfrog"})
 	_, err = extractGitParamsFromEnvs()
 	assert.EqualError(t, err, "'JF_GIT_TOKEN' environment variable is missing")
+
+	SetEnvAndAssert(t, map[string]string{GitTokenEnv: "token"})
+	_, err = extractGitParamsFromEnvs()
+	assert.EqualError(t, err, "'JF_GIT_REPO' environment variable is missing")
 }
 
 func TestExtractAndAssertRepoParams(t *testing.T) {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/frogbot#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
---

Bug:
When forgetting to set tup JF_GIT_REPO param it resolved in panic call.

Fix:
Enforce mandatory field.

Result:
```
18:20:51 [🔵Info] Frogbot version: 0.0.0
18:20:51 [🚨Error] 'JF_GIT_REPO' environment variable is missing
```