### PR TITLE
Aggregate Fixes per branch

### DIFF
--- a/scanrepository/scanrepository.go
+++ b/scanrepository/scanrepository.go
@@ -338,7 +338,7 @@ func (cfp *ScanRepositoryCmd) openFixingPullRequest(fixBranchName string, vulnDe
 // openAggregatedPullRequest handles the opening or updating of a pull request when the aggregate mode is active.
 // If a pull request is already open, Frogbot will update the branch and the pull request body.
 func (cfp *ScanRepositoryCmd) openAggregatedPullRequest(fixBranchName string, pullRequestInfo *vcsclient.PullRequestInfo, vulnerabilities []*utils.VulnerabilityDetails) (err error) {
-	commitMessage := cfp.gitManager.GenerateAggregatedCommitMessage(cfp.scanDetails.BaseBranch(), cfp.projectTech)
+	commitMessage := cfp.gitManager.GenerateAggregatedCommitMessage(cfp.projectTech)
 	if err = cfp.gitManager.AddAllAndCommit(commitMessage); err != nil {
 		return
 	}
@@ -360,7 +360,7 @@ func (cfp *ScanRepositoryCmd) openAggregatedPullRequest(fixBranchName string, pu
 func (cfp *ScanRepositoryCmd) preparePullRequestDetails(vulnerabilitiesDetails ...*utils.VulnerabilityDetails) (prTitle string, prBody string, err error) {
 	if cfp.dryRun && cfp.aggregateFixes {
 		// For testings, don't compare pull request body as scan results order may change.
-		return cfp.gitManager.GenerateAggregatedPullRequestTitle(cfp.scanDetails.BaseBranch(), cfp.projectTech), "", nil
+		return cfp.gitManager.GenerateAggregatedPullRequestTitle(cfp.projectTech), "", nil
 	}
 	vulnerabilitiesRows := utils.ExtractVulnerabilitiesDetailsToRows(vulnerabilitiesDetails)
 	prBody = cfp.OutputWriter.VulnerabilitiesTitle(false) + "\n" + cfp.OutputWriter.VulnerabilitiesContent(vulnerabilitiesRows) + cfp.OutputWriter.UntitledForJasMsg() + cfp.OutputWriter.Footer()
@@ -369,7 +369,7 @@ func (cfp *ScanRepositoryCmd) preparePullRequestDetails(vulnerabilitiesDetails .
 		if scanHash, err = utils.VulnerabilityDetailsToMD5Hash(vulnerabilitiesRows...); err != nil {
 			return
 		}
-		return cfp.gitManager.GenerateAggregatedPullRequestTitle(cfp.scanDetails.BaseBranch(), cfp.projectTech), prBody + outputwriter.MarkdownComment(fmt.Sprintf("Checksum: %s", scanHash)), nil
+		return cfp.gitManager.GenerateAggregatedPullRequestTitle(cfp.projectTech), prBody + outputwriter.MarkdownComment(fmt.Sprintf("Checksum: %s", scanHash)), nil
 	}
 	// In separate pull requests there is only one vulnerability
 	vulnDetails := vulnerabilitiesDetails[0]

--- a/scanrepository/scanrepository.go
+++ b/scanrepository/scanrepository.go
@@ -338,7 +338,7 @@ func (cfp *ScanRepositoryCmd) openFixingPullRequest(fixBranchName string, vulnDe
 // openAggregatedPullRequest handles the opening or updating of a pull request when the aggregate mode is active.
 // If a pull request is already open, Frogbot will update the branch and the pull request body.
 func (cfp *ScanRepositoryCmd) openAggregatedPullRequest(fixBranchName string, pullRequestInfo *vcsclient.PullRequestInfo, vulnerabilities []*utils.VulnerabilityDetails) (err error) {
-	commitMessage := cfp.gitManager.GenerateAggregatedCommitMessage(cfp.projectTech)
+	commitMessage := cfp.gitManager.GenerateAggregatedCommitMessage(cfp.scanDetails.BaseBranch(), cfp.projectTech)
 	if err = cfp.gitManager.AddAllAndCommit(commitMessage); err != nil {
 		return
 	}
@@ -360,7 +360,7 @@ func (cfp *ScanRepositoryCmd) openAggregatedPullRequest(fixBranchName string, pu
 func (cfp *ScanRepositoryCmd) preparePullRequestDetails(vulnerabilitiesDetails ...*utils.VulnerabilityDetails) (prTitle string, prBody string, err error) {
 	if cfp.dryRun && cfp.aggregateFixes {
 		// For testings, don't compare pull request body as scan results order may change.
-		return cfp.gitManager.GenerateAggregatedPullRequestTitle(cfp.projectTech), "", nil
+		return cfp.gitManager.GenerateAggregatedPullRequestTitle(cfp.scanDetails.BaseBranch(), cfp.projectTech), "", nil
 	}
 	vulnerabilitiesRows := utils.ExtractVulnerabilitiesDetailsToRows(vulnerabilitiesDetails)
 	prBody = cfp.OutputWriter.VulnerabilitiesTitle(false) + "\n" + cfp.OutputWriter.VulnerabilitiesContent(vulnerabilitiesRows) + cfp.OutputWriter.UntitledForJasMsg() + cfp.OutputWriter.Footer()
@@ -369,7 +369,7 @@ func (cfp *ScanRepositoryCmd) preparePullRequestDetails(vulnerabilitiesDetails .
 		if scanHash, err = utils.VulnerabilityDetailsToMD5Hash(vulnerabilitiesRows...); err != nil {
 			return
 		}
-		return cfp.gitManager.GenerateAggregatedPullRequestTitle(cfp.projectTech), prBody + outputwriter.MarkdownComment(fmt.Sprintf("Checksum: %s", scanHash)), nil
+		return cfp.gitManager.GenerateAggregatedPullRequestTitle(cfp.scanDetails.BaseBranch(), cfp.projectTech), prBody + outputwriter.MarkdownComment(fmt.Sprintf("Checksum: %s", scanHash)), nil
 	}
 	// In separate pull requests there is only one vulnerability
 	vulnDetails := vulnerabilitiesDetails[0]

--- a/scanrepository/scanrepository.go
+++ b/scanrepository/scanrepository.go
@@ -260,10 +260,7 @@ func (cfp *ScanRepositoryCmd) fixMultiplePackages(fullProjectPath string, vulner
 // Otherwise, it performs a force push to the same branch and reopens the pull request if it was closed.
 // Only one aggregated pull request should remain open at all times.
 func (cfp *ScanRepositoryCmd) fixIssuesSinglePR(vulnerabilitiesMap map[string]map[string]*utils.VulnerabilityDetails) (err error) {
-	aggregatedFixBranchName, err := cfp.gitManager.GenerateAggregatedFixBranchName(cfp.projectTech)
-	if err != nil {
-		return
-	}
+	aggregatedFixBranchName := cfp.gitManager.GenerateAggregatedFixBranchName(cfp.scanDetails.BaseBranch(), cfp.projectTech)
 	existingPullRequestDetails, err := cfp.getOpenPullRequestBySourceBranch(aggregatedFixBranchName)
 	if err != nil {
 		return

--- a/scanrepository/scanrepository_test.go
+++ b/scanrepository/scanrepository_test.go
@@ -664,6 +664,9 @@ random body
 func TestPreparePullRequestDetails(t *testing.T) {
 	cfp := ScanRepositoryCmd{OutputWriter: &outputwriter.StandardOutput{}, gitManager: &utils.GitManager{}}
 	cfp.OutputWriter.SetJasOutputFlags(true, false)
+	targetBranch := "master"
+	// Base branch refers to the origin
+	cfp.scanDetails.SetBaseBranch(targetBranch)
 	vulnerabilities := []*utils.VulnerabilityDetails{
 		{
 			VulnerabilityOrViolationRow: formats.VulnerabilityOrViolationRow{
@@ -681,7 +684,6 @@ func TestPreparePullRequestDetails(t *testing.T) {
 	}
 	expectedPrBody := "<div align='center'>\n\n[![](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/vulnerabilitiesFixBannerPR.png)](https://github.com/jfrog/frogbot#readme)\n\n</div>\n\n\n\n## 📦 Vulnerable Dependencies\n\n### ✍️ Summary\n\n<div align=\"center\">\n\n\n| SEVERITY                | DIRECT DEPENDENCIES                  | IMPACTED DEPENDENCY                   | FIXED VERSIONS                       | CVES                       |\n| :---------------------: | :----------------------------------: | :-----------------------------------: | :---------------------------------: | :---------------------------------: | \n| ![](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/applicableHighSeverity.png)<br>    High |  | package1:1.0.0 | 1.0.0<br>2.0.0 | CVE-2022-1234 |\n\n</div>\n\n## 🔬 Research Details\n\n\n**Description:**\nsummary\n\n\n---\n<div align=\"center\">\n\n[🐸 JFrog Frogbot](https://github.com/jfrog/frogbot#readme)\n\n</div>"
 	prTitle, prBody, err := cfp.preparePullRequestDetails(vulnerabilities...)
-	targetBranch := "master"
 	assert.NoError(t, err)
 	assert.Equal(t, "[🐸 Frogbot] Update version of package1 to 1.0.0", prTitle)
 	assert.Equal(t, expectedPrBody, prBody)

--- a/scanrepository/scanrepository_test.go
+++ b/scanrepository/scanrepository_test.go
@@ -105,9 +105,10 @@ func TestScanRepositoryCmd_Run(t *testing.T) {
 			configPath:                     "../testdata/scanrepository/cmd/aggregate-multi-project/.frogbot/frogbot-config.yml",
 		},
 		{
-			testName:                       "aggregate-no-vul",
-			expectedPackagesInBranch:       map[string][]string{"frogbot-update-Pip-dependencies-master": {}},
-			expectedVersionUpdatesInBranch: map[string][]string{"frogbot-update-Pip-dependencies-master": {}},
+			testName: "aggregate-no-vul",
+			// No branch is being created because there are no vulnerabilities.
+			expectedPackagesInBranch:       map[string][]string{"master": {}},
+			expectedVersionUpdatesInBranch: map[string][]string{"master": {}},
 			packageDescriptorPaths:         []string{"package.json"},
 			aggregateFixes:                 true,
 		},
@@ -680,6 +681,7 @@ func TestPreparePullRequestDetails(t *testing.T) {
 	}
 	expectedPrBody := "<div align='center'>\n\n[![](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/vulnerabilitiesFixBannerPR.png)](https://github.com/jfrog/frogbot#readme)\n\n</div>\n\n\n\n## 📦 Vulnerable Dependencies\n\n### ✍️ Summary\n\n<div align=\"center\">\n\n\n| SEVERITY                | DIRECT DEPENDENCIES                  | IMPACTED DEPENDENCY                   | FIXED VERSIONS                       | CVES                       |\n| :---------------------: | :----------------------------------: | :-----------------------------------: | :---------------------------------: | :---------------------------------: | \n| ![](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/applicableHighSeverity.png)<br>    High |  | package1:1.0.0 | 1.0.0<br>2.0.0 | CVE-2022-1234 |\n\n</div>\n\n## 🔬 Research Details\n\n\n**Description:**\nsummary\n\n\n---\n<div align=\"center\">\n\n[🐸 JFrog Frogbot](https://github.com/jfrog/frogbot#readme)\n\n</div>"
 	prTitle, prBody, err := cfp.preparePullRequestDetails(vulnerabilities...)
+	targetBranch := "master"
 	assert.NoError(t, err)
 	assert.Equal(t, "[🐸 Frogbot] Update version of package1 to 1.0.0", prTitle)
 	assert.Equal(t, expectedPrBody, prBody)
@@ -700,13 +702,13 @@ func TestPreparePullRequestDetails(t *testing.T) {
 	expectedPrBody = "<div align='center'>\n\n[![](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/vulnerabilitiesFixBannerPR.png)](https://github.com/jfrog/frogbot#readme)\n\n</div>\n\n\n\n## 📦 Vulnerable Dependencies\n\n### ✍️ Summary\n\n<div align=\"center\">\n\n\n| SEVERITY                | DIRECT DEPENDENCIES                  | IMPACTED DEPENDENCY                   | FIXED VERSIONS                       | CVES                       |\n| :---------------------: | :----------------------------------: | :-----------------------------------: | :---------------------------------: | :---------------------------------: | \n| ![](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/applicableHighSeverity.png)<br>    High |  | package1:1.0.0 | 1.0.0<br>2.0.0 | CVE-2022-1234 |\n| ![](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/applicableCriticalSeverity.png)<br>Critical |  | package2:2.0.0 | 2.0.0<br>3.0.0 | CVE-2022-4321 |\n\n</div>\n\n## 🔬 Research Details\n\n<details>\n<summary> <b>[ CVE-2022-1234 ] package1 1.0.0</b> </summary>\n<br>\n\n**Description:**\nsummary\n\n\n</details>\n\n\n<details>\n<summary> <b>[ CVE-2022-4321 ] package2 2.0.0</b> </summary>\n<br>\n\n**Description:**\nsummary\n\n\n</details>\n\n\n---\n<div align=\"center\">\n\n[🐸 JFrog Frogbot](https://github.com/jfrog/frogbot#readme)\n\n</div>\n\n[comment]: <> (Checksum: bec823edaceb5d0478b789798e819bde)\n"
 	prTitle, prBody, err = cfp.preparePullRequestDetails(vulnerabilities...)
 	assert.NoError(t, err)
-	assert.Equal(t, cfp.gitManager.GenerateAggregatedPullRequestTitle([]coreutils.Technology{}), prTitle)
+	assert.Equal(t, cfp.gitManager.GenerateAggregatedPullRequestTitle(targetBranch, []coreutils.Technology{}), prTitle)
 	assert.Equal(t, expectedPrBody, prBody)
 	cfp.OutputWriter = &outputwriter.SimplifiedOutput{}
 	expectedPrBody = "**🚨 This automated pull request was created by Frogbot and fixes the below:**\n\n\n---\n## 📦 Vulnerable Dependencies\n---\n\n### ✍️ Summary\n\n\n| SEVERITY                | DIRECT DEPENDENCIES                  | IMPACTED DEPENDENCY                   | FIXED VERSIONS                       | CVES                       |\n| :---------------------: | :----------------------------------: | :-----------------------------------: | :---------------------------------: | :---------------------------------: | \n| High |   | package1:1.0.0 | 1.0.0, 2.0.0 | CVE-2022-1234 |\n| Critical |   | package2:2.0.0 | 2.0.0, 3.0.0 | CVE-2022-4321 |\n\n---\n## 🔬 Research Details\n---\n\n\n#### [ CVE-2022-1234 ] package1 1.0.0\n\n\n**Description:**\nsummary\n\n\n#### [ CVE-2022-4321 ] package2 2.0.0\n\n\n**Description:**\nsummary\n\n\n\n---\n**Frogbot** also supports **Contextual Analysis, Secret Detection and IaC Vulnerabilities Scanning**. This features are included as part of the [JFrog Advanced Security](https://jfrog.com/xray/) package, which isn't enabled on your system.\n\n[🐸 JFrog Frogbot](https://github.com/jfrog/frogbot#readme)\n\n[comment]: <> (Checksum: bec823edaceb5d0478b789798e819bde)\n"
 	prTitle, prBody, err = cfp.preparePullRequestDetails(vulnerabilities...)
 	assert.NoError(t, err)
-	assert.Equal(t, cfp.gitManager.GenerateAggregatedPullRequestTitle([]coreutils.Technology{}), prTitle)
+	assert.Equal(t, cfp.gitManager.GenerateAggregatedPullRequestTitle(prTitle, []coreutils.Technology{}), prTitle)
 	assert.Equal(t, expectedPrBody, prBody)
 }
 

--- a/scanrepository/scanrepository_test.go
+++ b/scanrepository/scanrepository_test.go
@@ -83,40 +83,42 @@ func TestScanRepositoryCmd_Run(t *testing.T) {
 	}{
 		{
 			testName:                       "aggregate",
-			expectedPackagesInBranch:       map[string][]string{"frogbot-update-npm-dependencies": {"uuid", "minimist", "mpath"}},
-			expectedVersionUpdatesInBranch: map[string][]string{"frogbot-update-npm-dependencies": {"^1.2.6", "^9.0.0", "^0.8.4"}},
+			expectedPackagesInBranch:       map[string][]string{"frogbot-update-npm-dependencies-master": {"uuid", "minimist", "mpath"}},
+			expectedVersionUpdatesInBranch: map[string][]string{"frogbot-update-npm-dependencies-master": {"^1.2.6", "^9.0.0", "^0.8.4"}},
 			packageDescriptorPaths:         []string{"package.json"},
 			aggregateFixes:                 true,
 		},
 		{
 			testName:                       "aggregate-multi-dir",
-			expectedPackagesInBranch:       map[string][]string{"frogbot-update-npm-dependencies": {"uuid", "minimatch", "mpath", "minimist"}},
-			expectedVersionUpdatesInBranch: map[string][]string{"frogbot-update-npm-dependencies": {"^1.2.6", "^9.0.0", "^0.8.4", "^3.0.5"}},
+			expectedPackagesInBranch:       map[string][]string{"frogbot-update-npm-dependencies-master": {"uuid", "minimatch", "mpath", "minimist"}},
+			expectedVersionUpdatesInBranch: map[string][]string{"frogbot-update-npm-dependencies-master": {"^1.2.6", "^9.0.0", "^0.8.4", "^3.0.5"}},
 			packageDescriptorPaths:         []string{"npm1/package.json", "npm2/package.json"},
 			aggregateFixes:                 true,
 			configPath:                     "../testdata/scanrepository/cmd/aggregate-multi-dir/.frogbot/frogbot-config.yml",
 		},
 		{
 			testName:                       "aggregate-multi-project",
-			expectedPackagesInBranch:       map[string][]string{"frogbot-update-npm-dependencies": {"uuid", "minimatch", "mpath"}, "frogbot-update-Pip-dependencies": {"pyjwt", "pexpect"}},
-			expectedVersionUpdatesInBranch: map[string][]string{"frogbot-update-npm-dependencies": {"^9.0.0", "^0.8.4", "^3.0.5"}, "frogbot-update-Pip-dependencies": {"2.4.0"}},
+			expectedPackagesInBranch:       map[string][]string{"frogbot-update-npm-dependencies-master": {"uuid", "minimatch", "mpath"}, "frogbot-update-Pip-dependencies-master": {"pyjwt", "pexpect"}},
+			expectedVersionUpdatesInBranch: map[string][]string{"frogbot-update-npm-dependencies-master": {"^9.0.0", "^0.8.4", "^3.0.5"}, "frogbot-update-Pip-dependencies-master": {"2.4.0"}},
 			packageDescriptorPaths:         []string{"npm/package.json", "pip/requirements.txt"},
 			aggregateFixes:                 true,
 			configPath:                     "../testdata/scanrepository/cmd/aggregate-multi-project/.frogbot/frogbot-config.yml",
 		},
 		{
 			testName:                       "aggregate-no-vul",
-			expectedPackagesInBranch:       map[string][]string{"master": {}},
-			expectedVersionUpdatesInBranch: map[string][]string{"master": {}},
+			expectedPackagesInBranch:       map[string][]string{"frogbot-update-Pip-dependencies-master": {}},
+			expectedVersionUpdatesInBranch: map[string][]string{"frogbot-update-Pip-dependencies-master": {}},
 			packageDescriptorPaths:         []string{"package.json"},
 			aggregateFixes:                 true,
 		},
 		{
-			testName:                       "aggregate-cant-fix",
-			expectedPackagesInBranch:       map[string][]string{"frogbot-update-Pip-dependencies": {}},
-			expectedVersionUpdatesInBranch: map[string][]string{"frogbot-update-Pip-dependencies": {}},
-			packageDescriptorPaths:         []string{"setup.py"}, // This is a build tool dependency which should not be fixed
-			aggregateFixes:                 true,
+			testName: "aggregate-cant-fix",
+			// Branch name stays master as no new branch is being created
+			expectedPackagesInBranch:       map[string][]string{"master": {}},
+			expectedVersionUpdatesInBranch: map[string][]string{"master": {}},
+			// This is a build tool dependency which should not be fixed.
+			packageDescriptorPaths: []string{"setup.py"},
+			aggregateFixes:         true,
 		},
 		{
 			testName:                       "non-aggregate",

--- a/scanrepository/scanrepository_test.go
+++ b/scanrepository/scanrepository_test.go
@@ -666,6 +666,7 @@ func TestPreparePullRequestDetails(t *testing.T) {
 	cfp.OutputWriter.SetJasOutputFlags(true, false)
 	targetBranch := "master"
 	// Base branch refers to the origin
+	cfp.scanDetails = utils.NewScanDetails(nil, nil, nil)
 	cfp.scanDetails.SetBaseBranch(targetBranch)
 	vulnerabilities := []*utils.VulnerabilityDetails{
 		{

--- a/scanrepository/scanrepository_test.go
+++ b/scanrepository/scanrepository_test.go
@@ -664,10 +664,6 @@ random body
 func TestPreparePullRequestDetails(t *testing.T) {
 	cfp := ScanRepositoryCmd{OutputWriter: &outputwriter.StandardOutput{}, gitManager: &utils.GitManager{}}
 	cfp.OutputWriter.SetJasOutputFlags(true, false)
-	targetBranch := "master"
-	// Base branch refers to the origin
-	cfp.scanDetails = utils.NewScanDetails(nil, nil, nil)
-	cfp.scanDetails.SetBaseBranch(targetBranch)
 	vulnerabilities := []*utils.VulnerabilityDetails{
 		{
 			VulnerabilityOrViolationRow: formats.VulnerabilityOrViolationRow{
@@ -705,13 +701,13 @@ func TestPreparePullRequestDetails(t *testing.T) {
 	expectedPrBody = "<div align='center'>\n\n[![](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/vulnerabilitiesFixBannerPR.png)](https://github.com/jfrog/frogbot#readme)\n\n</div>\n\n\n\n## 📦 Vulnerable Dependencies\n\n### ✍️ Summary\n\n<div align=\"center\">\n\n\n| SEVERITY                | DIRECT DEPENDENCIES                  | IMPACTED DEPENDENCY                   | FIXED VERSIONS                       | CVES                       |\n| :---------------------: | :----------------------------------: | :-----------------------------------: | :---------------------------------: | :---------------------------------: | \n| ![](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/applicableHighSeverity.png)<br>    High |  | package1:1.0.0 | 1.0.0<br>2.0.0 | CVE-2022-1234 |\n| ![](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/applicableCriticalSeverity.png)<br>Critical |  | package2:2.0.0 | 2.0.0<br>3.0.0 | CVE-2022-4321 |\n\n</div>\n\n## 🔬 Research Details\n\n<details>\n<summary> <b>[ CVE-2022-1234 ] package1 1.0.0</b> </summary>\n<br>\n\n**Description:**\nsummary\n\n\n</details>\n\n\n<details>\n<summary> <b>[ CVE-2022-4321 ] package2 2.0.0</b> </summary>\n<br>\n\n**Description:**\nsummary\n\n\n</details>\n\n\n---\n<div align=\"center\">\n\n[🐸 JFrog Frogbot](https://github.com/jfrog/frogbot#readme)\n\n</div>\n\n[comment]: <> (Checksum: bec823edaceb5d0478b789798e819bde)\n"
 	prTitle, prBody, err = cfp.preparePullRequestDetails(vulnerabilities...)
 	assert.NoError(t, err)
-	assert.Equal(t, cfp.gitManager.GenerateAggregatedPullRequestTitle(targetBranch, []coreutils.Technology{}), prTitle)
+	assert.Equal(t, cfp.gitManager.GenerateAggregatedPullRequestTitle([]coreutils.Technology{}), prTitle)
 	assert.Equal(t, expectedPrBody, prBody)
 	cfp.OutputWriter = &outputwriter.SimplifiedOutput{}
 	expectedPrBody = "**🚨 This automated pull request was created by Frogbot and fixes the below:**\n\n\n---\n## 📦 Vulnerable Dependencies\n---\n\n### ✍️ Summary\n\n\n| SEVERITY                | DIRECT DEPENDENCIES                  | IMPACTED DEPENDENCY                   | FIXED VERSIONS                       | CVES                       |\n| :---------------------: | :----------------------------------: | :-----------------------------------: | :---------------------------------: | :---------------------------------: | \n| High |   | package1:1.0.0 | 1.0.0, 2.0.0 | CVE-2022-1234 |\n| Critical |   | package2:2.0.0 | 2.0.0, 3.0.0 | CVE-2022-4321 |\n\n---\n## 🔬 Research Details\n---\n\n\n#### [ CVE-2022-1234 ] package1 1.0.0\n\n\n**Description:**\nsummary\n\n\n#### [ CVE-2022-4321 ] package2 2.0.0\n\n\n**Description:**\nsummary\n\n\n\n---\n**Frogbot** also supports **Contextual Analysis, Secret Detection and IaC Vulnerabilities Scanning**. This features are included as part of the [JFrog Advanced Security](https://jfrog.com/xray/) package, which isn't enabled on your system.\n\n[🐸 JFrog Frogbot](https://github.com/jfrog/frogbot#readme)\n\n[comment]: <> (Checksum: bec823edaceb5d0478b789798e819bde)\n"
 	prTitle, prBody, err = cfp.preparePullRequestDetails(vulnerabilities...)
 	assert.NoError(t, err)
-	assert.Equal(t, cfp.gitManager.GenerateAggregatedPullRequestTitle(prTitle, []coreutils.Technology{}), prTitle)
+	assert.Equal(t, cfp.gitManager.GenerateAggregatedPullRequestTitle([]coreutils.Technology{}), prTitle)
 	assert.Equal(t, expectedPrBody, prBody)
 }
 

--- a/utils/consts.go
+++ b/utils/consts.go
@@ -87,7 +87,6 @@ const (
 	CommitMessageTemplate                    = "Upgrade " + PackagePlaceHolder + " to " + FixVersionPlaceHolder
 	PullRequestTitleTemplate                 = outputwriter.FrogbotTitlePrefix + " Update version of " + PackagePlaceHolder + " to " + FixVersionPlaceHolder
 	AggregatePullRequestTitleDefaultTemplate = outputwriter.FrogbotTitlePrefix + " Update %s dependencies"
-	AggregatePullRequestTitle                = outputwriter.FrogbotTitlePrefix + " Update dependencies"
 	// Frogbot Git author details showed in commits
 	frogbotAuthorName  = "JFrog-Frogbot"
 	frogbotAuthorEmail = "eco-system+frogbot@jfrog.com"

--- a/utils/git.go
+++ b/utils/git.go
@@ -327,11 +327,11 @@ func (gm *GitManager) GenerateCommitMessage(impactedPackage string, fixVersion s
 	return formatStringWithPlaceHolders(template, impactedPackage, fixVersion, "", true)
 }
 
-func (gm *GitManager) GenerateAggregatedCommitMessage(tech []coreutils.Technology) string {
+func (gm *GitManager) GenerateAggregatedCommitMessage(targetBranch string, tech []coreutils.Technology) string {
 	template := gm.customTemplates.commitMessageTemplate
 	if template == "" {
 		// In aggregated mode, commit message and PR title are the same.
-		template = gm.GenerateAggregatedPullRequestTitle(tech)
+		template = gm.GenerateAggregatedPullRequestTitle(targetBranch, tech)
 	}
 	return formatStringWithPlaceHolders(template, "", "", "", true)
 }
@@ -386,13 +386,13 @@ func (gm *GitManager) GeneratePullRequestTitle(impactedPackage string, version s
 	return formatStringWithPlaceHolders(template, impactedPackage, version, "", true)
 }
 
-func (gm *GitManager) GenerateAggregatedPullRequestTitle(tech []coreutils.Technology) string {
+func (gm *GitManager) GenerateAggregatedPullRequestTitle(targetBranch string, tech []coreutils.Technology) string {
 	template := gm.getPullRequestTitleTemplate(tech)
 	// If no technologies are provided, return the template as-is
 	if len(tech) == 0 {
 		return normalizeWhitespaces(strings.ReplaceAll(template, "%s", ""))
 	}
-	return fmt.Sprintf(template, techArrayToString(tech, pullRequestTitleTechSeparator))
+	return fmt.Sprintf(template, targetBranch+" "+techArrayToString(tech, pullRequestTitleTechSeparator))
 }
 
 func (gm *GitManager) getPullRequestTitleTemplate(tech []coreutils.Technology) string {

--- a/utils/git.go
+++ b/utils/git.go
@@ -354,13 +354,13 @@ func formatStringWithPlaceHolders(str, impactedPackage, fixVersion, hash string,
 	return str
 }
 
-func formatAggregatedStringWithPlaceHolders(str, sourceBranch, hash string) string {
+func formatAggregatedStringWithPlaceHolders(str, baseBranch, hash string) string {
 	// Replace branch placeholder
 	str = strings.Replace(str, BranchHashPlaceHolder, hash, 1)
 	// Remove spaces
 	str = strings.ReplaceAll(str, " ", "_")
-	// Add target branch suffix
-	return str + "-" + sourceBranch
+	// Add base branch as suffix
+	return str + "-" + baseBranch
 }
 
 func (gm *GitManager) GenerateFixBranchName(branch string, impactedPackage string, fixVersion string) (string, error) {
@@ -405,13 +405,13 @@ func (gm *GitManager) getPullRequestTitleTemplate(tech []coreutils.Technology) s
 }
 
 // GenerateAggregatedFixBranchName Generating a consistent branch name to enable branch updates
-// and to ensure that there is only one Frogbot branch in aggregated mode for each scanned branch.
-func (gm *GitManager) GenerateAggregatedFixBranchName(originBranch string, tech []coreutils.Technology) (fixBranchName string) {
+// and to ensure that there is only one Frogbot aggregate pull request from each base branch scanned.
+func (gm *GitManager) GenerateAggregatedFixBranchName(baseBranch string, tech []coreutils.Technology) (fixBranchName string) {
 	branchFormat := gm.customTemplates.branchNameTemplate
 	if branchFormat == "" {
 		branchFormat = AggregatedBranchNameTemplate
 	}
-	return formatAggregatedStringWithPlaceHolders(branchFormat, originBranch, techArrayToString(tech, fixBranchTechSeparator))
+	return formatAggregatedStringWithPlaceHolders(branchFormat, baseBranch, techArrayToString(tech, fixBranchTechSeparator))
 }
 
 // dryRunClone clones an existing repository from our testdata folder into the destination folder for testing purposes.

--- a/utils/git.go
+++ b/utils/git.go
@@ -354,6 +354,15 @@ func formatStringWithPlaceHolders(str, impactedPackage, fixVersion, hash string,
 	return str
 }
 
+func formatAggregatedStringWithPlaceHolders(str, sourceBranch, hash string) string {
+	// Replace branch placeholder
+	str = strings.Replace(str, BranchHashPlaceHolder, hash, 1)
+	// Remove spaces
+	str = strings.ReplaceAll(str, " ", "_")
+	// Add target branch suffix
+	return str + "-" + sourceBranch
+}
+
 func (gm *GitManager) GenerateFixBranchName(branch string, impactedPackage string, fixVersion string) (string, error) {
 	hash, err := Md5Hash("frogbot", branch, impactedPackage, fixVersion)
 	if err != nil {
@@ -396,13 +405,13 @@ func (gm *GitManager) getPullRequestTitleTemplate(tech []coreutils.Technology) s
 }
 
 // GenerateAggregatedFixBranchName Generating a consistent branch name to enable branch updates
-// and to ensure that there is only one Frogbot branch in aggregated mode.
-func (gm *GitManager) GenerateAggregatedFixBranchName(tech []coreutils.Technology) (fixBranchName string, err error) {
+// and to ensure that there is only one Frogbot branch in aggregated mode for each scanned branch.
+func (gm *GitManager) GenerateAggregatedFixBranchName(originBranch string, tech []coreutils.Technology) (fixBranchName string) {
 	branchFormat := gm.customTemplates.branchNameTemplate
 	if branchFormat == "" {
 		branchFormat = AggregatedBranchNameTemplate
 	}
-	return formatStringWithPlaceHolders(branchFormat, "", "", techArrayToString(tech, fixBranchTechSeparator), false), nil
+	return formatAggregatedStringWithPlaceHolders(branchFormat, originBranch, techArrayToString(tech, fixBranchTechSeparator))
 }
 
 // dryRunClone clones an existing repository from our testdata folder into the destination folder for testing purposes.

--- a/utils/git.go
+++ b/utils/git.go
@@ -327,11 +327,11 @@ func (gm *GitManager) GenerateCommitMessage(impactedPackage string, fixVersion s
 	return formatStringWithPlaceHolders(template, impactedPackage, fixVersion, "", true)
 }
 
-func (gm *GitManager) GenerateAggregatedCommitMessage(targetBranch string, tech []coreutils.Technology) string {
+func (gm *GitManager) GenerateAggregatedCommitMessage(tech []coreutils.Technology) string {
 	template := gm.customTemplates.commitMessageTemplate
 	if template == "" {
 		// In aggregated mode, commit message and PR title are the same.
-		template = gm.GenerateAggregatedPullRequestTitle(targetBranch, tech)
+		template = gm.GenerateAggregatedPullRequestTitle(tech)
 	}
 	return formatStringWithPlaceHolders(template, "", "", "", true)
 }
@@ -386,13 +386,13 @@ func (gm *GitManager) GeneratePullRequestTitle(impactedPackage string, version s
 	return formatStringWithPlaceHolders(template, impactedPackage, version, "", true)
 }
 
-func (gm *GitManager) GenerateAggregatedPullRequestTitle(targetBranch string, tech []coreutils.Technology) string {
+func (gm *GitManager) GenerateAggregatedPullRequestTitle(tech []coreutils.Technology) string {
 	template := gm.getPullRequestTitleTemplate(tech)
 	// If no technologies are provided, return the template as-is
 	if len(tech) == 0 {
 		return normalizeWhitespaces(strings.ReplaceAll(template, "%s", ""))
 	}
-	return fmt.Sprintf(template, targetBranch+" "+techArrayToString(tech, pullRequestTitleTechSeparator))
+	return fmt.Sprintf(template, techArrayToString(tech, pullRequestTitleTechSeparator))
 }
 
 func (gm *GitManager) getPullRequestTitleTemplate(tech []coreutils.Technology) string {

--- a/utils/git_test.go
+++ b/utils/git_test.go
@@ -168,12 +168,12 @@ func TestGitManager_GenerateAggregatedCommitMessage(t *testing.T) {
 		gitManager GitManager
 		expected   string
 	}{
-		{gitManager: GitManager{}, expected: "[🐸 Frogbot] Update master Pipenv dependencies"},
+		{gitManager: GitManager{}, expected: "[🐸 Frogbot] Update Pipenv dependencies"},
 		{gitManager: GitManager{customTemplates: CustomTemplates{commitMessageTemplate: "custom_template"}}, expected: "custom_template"},
 	}
 	for _, test := range testCases {
 		t.Run(test.expected, func(t *testing.T) {
-			commit := test.gitManager.GenerateAggregatedCommitMessage("master", []coreutils.Technology{coreutils.Pipenv})
+			commit := test.gitManager.GenerateAggregatedCommitMessage([]coreutils.Technology{coreutils.Pipenv})
 			assert.Equal(t, commit, test.expected)
 		})
 	}
@@ -315,23 +315,22 @@ func TestGetAggregatedPullRequestTitle(t *testing.T) {
 		expected string
 	}{
 		{gm: defaultGm, tech: []coreutils.Technology{}, expected: "[🐸 Frogbot] Update dependencies"},
-		{gm: defaultGm, tech: []coreutils.Technology{coreutils.Maven}, expected: "[🐸 Frogbot] Update master Maven dependencies"},
-		{gm: defaultGm, tech: []coreutils.Technology{coreutils.Gradle}, expected: "[🐸 Frogbot] Update master Gradle dependencies"},
-		{gm: defaultGm, tech: []coreutils.Technology{coreutils.Npm}, expected: "[🐸 Frogbot] Update master npm dependencies"},
-		{gm: defaultGm, tech: []coreutils.Technology{coreutils.Yarn}, expected: "[🐸 Frogbot] Update master Yarn dependencies"},
-		{gm: GitManager{customTemplates: CustomTemplates{pullRequestTitleTemplate: "[Dependencies] My template "}}, tech: []coreutils.Technology{coreutils.Yarn}, expected: "[Dependencies] My template - master Yarn Dependencies"},
-		{gm: GitManager{customTemplates: CustomTemplates{pullRequestTitleTemplate: ""}}, tech: []coreutils.Technology{coreutils.Yarn}, expected: "[🐸 Frogbot] Update master Yarn dependencies"},
-		{gm: GitManager{customTemplates: CustomTemplates{pullRequestTitleTemplate: "[Feature] %s hello"}}, tech: []coreutils.Technology{coreutils.Yarn}, expected: "[Feature] hello - master Yarn Dependencies"},
-		{gm: GitManager{customTemplates: CustomTemplates{pullRequestTitleTemplate: "[Feature] %s %d hello"}}, tech: []coreutils.Technology{coreutils.Yarn}, expected: "[Feature] hello - master Yarn Dependencies"},
-		{gm: GitManager{customTemplates: CustomTemplates{pullRequestTitleTemplate: "[Feature] %s %d hello"}}, tech: []coreutils.Technology{coreutils.Yarn}, expected: "[Feature] hello - master Yarn Dependencies"},
-		{gm: GitManager{customTemplates: CustomTemplates{pullRequestTitleTemplate: "[Feature] %s %f hello"}}, tech: []coreutils.Technology{coreutils.Yarn, coreutils.Go}, expected: "[Feature] hello - master Yarn,Go Dependencies"},
-		{gm: GitManager{customTemplates: CustomTemplates{pullRequestTitleTemplate: "[Feature] %s %d hello"}}, tech: []coreutils.Technology{coreutils.Yarn, coreutils.Go, coreutils.Npm}, expected: "[Feature] hello - master Yarn,Go,npm Dependencies"},
+		{gm: defaultGm, tech: []coreutils.Technology{coreutils.Maven}, expected: "[🐸 Frogbot] Update Maven dependencies"},
+		{gm: defaultGm, tech: []coreutils.Technology{coreutils.Gradle}, expected: "[🐸 Frogbot] Update Gradle dependencies"},
+		{gm: defaultGm, tech: []coreutils.Technology{coreutils.Npm}, expected: "[🐸 Frogbot] Update npm dependencies"},
+		{gm: defaultGm, tech: []coreutils.Technology{coreutils.Yarn}, expected: "[🐸 Frogbot] Update Yarn dependencies"},
+		{gm: GitManager{customTemplates: CustomTemplates{pullRequestTitleTemplate: "[Dependencies] My template "}}, tech: []coreutils.Technology{coreutils.Yarn}, expected: "[Dependencies] My template - Yarn Dependencies"},
+		{gm: GitManager{customTemplates: CustomTemplates{pullRequestTitleTemplate: ""}}, tech: []coreutils.Technology{coreutils.Yarn}, expected: "[🐸 Frogbot] Update Yarn dependencies"},
+		{gm: GitManager{customTemplates: CustomTemplates{pullRequestTitleTemplate: "[Feature] %s hello"}}, tech: []coreutils.Technology{coreutils.Yarn}, expected: "[Feature] hello - Yarn Dependencies"},
+		{gm: GitManager{customTemplates: CustomTemplates{pullRequestTitleTemplate: "[Feature] %s %d hello"}}, tech: []coreutils.Technology{coreutils.Yarn}, expected: "[Feature] hello - Yarn Dependencies"},
+		{gm: GitManager{customTemplates: CustomTemplates{pullRequestTitleTemplate: "[Feature] %s %d hello"}}, tech: []coreutils.Technology{coreutils.Yarn}, expected: "[Feature] hello - Yarn Dependencies"},
+		{gm: GitManager{customTemplates: CustomTemplates{pullRequestTitleTemplate: "[Feature] %s %f hello"}}, tech: []coreutils.Technology{coreutils.Yarn, coreutils.Go}, expected: "[Feature] hello - Yarn,Go Dependencies"},
+		{gm: GitManager{customTemplates: CustomTemplates{pullRequestTitleTemplate: "[Feature] %s %d hello"}}, tech: []coreutils.Technology{coreutils.Yarn, coreutils.Go, coreutils.Npm}, expected: "[Feature] hello - Yarn,Go,npm Dependencies"},
 		{gm: GitManager{customTemplates: CustomTemplates{pullRequestTitleTemplate: "[Feature] %s %d hello"}}, tech: []coreutils.Technology{}, expected: "[Feature] hello"},
 	}
 	for _, test := range testsCases {
 		t.Run(test.expected, func(t *testing.T) {
-			sourceBranch := "master"
-			title := test.gm.GenerateAggregatedPullRequestTitle(sourceBranch, test.tech)
+			title := test.gm.GenerateAggregatedPullRequestTitle(test.tech)
 			assert.Equal(t, test.expected, title)
 		})
 	}

--- a/utils/git_test.go
+++ b/utils/git_test.go
@@ -127,25 +127,37 @@ func TestGitManager_GeneratePullRequestTitle(t *testing.T) {
 
 func TestGitManager_GenerateAggregatedFixBranchName(t *testing.T) {
 	testCases := []struct {
-		gitManager GitManager
-		expected   string
-		desc       string
+		gitManager   GitManager
+		originBranch string
+		expected     string
+		desc         string
 	}{
 		{
-			expected:   "frogbot-update-Go-dependencies",
-			desc:       "No template",
-			gitManager: GitManager{},
+			expected:     "frogbot-update-Go-dependencies-main",
+			originBranch: "main",
+			desc:         "No template",
+			gitManager:   GitManager{},
+		}, {
+			expected:     "frogbot-update-Go-dependencies-v2",
+			originBranch: "v2",
+			desc:         "No template",
+			gitManager:   GitManager{},
 		},
 		{
-			expected:   "[feature]-Go",
-			desc:       "Custom template hash only",
-			gitManager: GitManager{customTemplates: CustomTemplates{branchNameTemplate: "[feature]-${BRANCH_NAME_HASH}"}},
+			expected:     "[feature]-Go-main",
+			originBranch: "main",
+			desc:         "Custom template hash only",
+			gitManager:   GitManager{customTemplates: CustomTemplates{branchNameTemplate: "[feature]-${BRANCH_NAME_HASH}"}},
+		}, {
+			expected:     "[feature]-Go-master",
+			originBranch: "master",
+			desc:         "Custom template hash only",
+			gitManager:   GitManager{customTemplates: CustomTemplates{branchNameTemplate: "[feature]-${BRANCH_NAME_HASH}"}},
 		},
 	}
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			titleOutput, err := test.gitManager.GenerateAggregatedFixBranchName([]coreutils.Technology{coreutils.Go})
-			assert.NoError(t, err)
+			titleOutput := test.gitManager.GenerateAggregatedFixBranchName(test.originBranch, []coreutils.Technology{coreutils.Go})
 			assert.Equal(t, test.expected, titleOutput)
 		})
 	}

--- a/utils/git_test.go
+++ b/utils/git_test.go
@@ -127,37 +127,37 @@ func TestGitManager_GeneratePullRequestTitle(t *testing.T) {
 
 func TestGitManager_GenerateAggregatedFixBranchName(t *testing.T) {
 	testCases := []struct {
-		gitManager   GitManager
-		originBranch string
-		expected     string
-		desc         string
+		gitManager GitManager
+		baseBranch string
+		expected   string
+		desc       string
 	}{
 		{
-			expected:     "frogbot-update-Go-dependencies-main",
-			originBranch: "main",
-			desc:         "No template",
-			gitManager:   GitManager{},
+			expected:   "frogbot-update-Go-dependencies-main",
+			baseBranch: "main",
+			desc:       "No template",
+			gitManager: GitManager{},
 		}, {
-			expected:     "frogbot-update-Go-dependencies-v2",
-			originBranch: "v2",
-			desc:         "No template",
-			gitManager:   GitManager{},
+			expected:   "frogbot-update-Go-dependencies-v2",
+			baseBranch: "v2",
+			desc:       "No template",
+			gitManager: GitManager{},
 		},
 		{
-			expected:     "[feature]-Go-main",
-			originBranch: "main",
-			desc:         "Custom template hash only",
-			gitManager:   GitManager{customTemplates: CustomTemplates{branchNameTemplate: "[feature]-${BRANCH_NAME_HASH}"}},
+			expected:   "[feature]-Go-main",
+			baseBranch: "main",
+			desc:       "Custom template hash only",
+			gitManager: GitManager{customTemplates: CustomTemplates{branchNameTemplate: "[feature]-${BRANCH_NAME_HASH}"}},
 		}, {
-			expected:     "[feature]-Go-master",
-			originBranch: "master",
-			desc:         "Custom template hash only",
-			gitManager:   GitManager{customTemplates: CustomTemplates{branchNameTemplate: "[feature]-${BRANCH_NAME_HASH}"}},
+			expected:   "[feature]-Go-master",
+			baseBranch: "master",
+			desc:       "Custom template hash only",
+			gitManager: GitManager{customTemplates: CustomTemplates{branchNameTemplate: "[feature]-${BRANCH_NAME_HASH}"}},
 		},
 	}
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			titleOutput := test.gitManager.GenerateAggregatedFixBranchName(test.originBranch, []coreutils.Technology{coreutils.Go})
+			titleOutput := test.gitManager.GenerateAggregatedFixBranchName(test.baseBranch, []coreutils.Technology{coreutils.Go})
 			assert.Equal(t, test.expected, titleOutput)
 		})
 	}

--- a/utils/git_test.go
+++ b/utils/git_test.go
@@ -168,12 +168,12 @@ func TestGitManager_GenerateAggregatedCommitMessage(t *testing.T) {
 		gitManager GitManager
 		expected   string
 	}{
-		{gitManager: GitManager{}, expected: "[🐸 Frogbot] Update Pipenv dependencies"},
+		{gitManager: GitManager{}, expected: "[🐸 Frogbot] Update master Pipenv dependencies"},
 		{gitManager: GitManager{customTemplates: CustomTemplates{commitMessageTemplate: "custom_template"}}, expected: "custom_template"},
 	}
 	for _, test := range testCases {
 		t.Run(test.expected, func(t *testing.T) {
-			commit := test.gitManager.GenerateAggregatedCommitMessage([]coreutils.Technology{coreutils.Pipenv})
+			commit := test.gitManager.GenerateAggregatedCommitMessage("master", []coreutils.Technology{coreutils.Pipenv})
 			assert.Equal(t, commit, test.expected)
 		})
 	}
@@ -315,22 +315,23 @@ func TestGetAggregatedPullRequestTitle(t *testing.T) {
 		expected string
 	}{
 		{gm: defaultGm, tech: []coreutils.Technology{}, expected: "[🐸 Frogbot] Update dependencies"},
-		{gm: defaultGm, tech: []coreutils.Technology{coreutils.Maven}, expected: "[🐸 Frogbot] Update Maven dependencies"},
-		{gm: defaultGm, tech: []coreutils.Technology{coreutils.Gradle}, expected: "[🐸 Frogbot] Update Gradle dependencies"},
-		{gm: defaultGm, tech: []coreutils.Technology{coreutils.Npm}, expected: "[🐸 Frogbot] Update npm dependencies"},
-		{gm: defaultGm, tech: []coreutils.Technology{coreutils.Yarn}, expected: "[🐸 Frogbot] Update Yarn dependencies"},
-		{gm: GitManager{customTemplates: CustomTemplates{pullRequestTitleTemplate: "[Dependencies] My template "}}, tech: []coreutils.Technology{coreutils.Yarn}, expected: "[Dependencies] My template - Yarn Dependencies"},
-		{gm: GitManager{customTemplates: CustomTemplates{pullRequestTitleTemplate: ""}}, tech: []coreutils.Technology{coreutils.Yarn}, expected: "[🐸 Frogbot] Update Yarn dependencies"},
-		{gm: GitManager{customTemplates: CustomTemplates{pullRequestTitleTemplate: "[Feature] %s hello"}}, tech: []coreutils.Technology{coreutils.Yarn}, expected: "[Feature] hello - Yarn Dependencies"},
-		{gm: GitManager{customTemplates: CustomTemplates{pullRequestTitleTemplate: "[Feature] %s %d hello"}}, tech: []coreutils.Technology{coreutils.Yarn}, expected: "[Feature] hello - Yarn Dependencies"},
-		{gm: GitManager{customTemplates: CustomTemplates{pullRequestTitleTemplate: "[Feature] %s %d hello"}}, tech: []coreutils.Technology{coreutils.Yarn}, expected: "[Feature] hello - Yarn Dependencies"},
-		{gm: GitManager{customTemplates: CustomTemplates{pullRequestTitleTemplate: "[Feature] %s %f hello"}}, tech: []coreutils.Technology{coreutils.Yarn, coreutils.Go}, expected: "[Feature] hello - Yarn,Go Dependencies"},
-		{gm: GitManager{customTemplates: CustomTemplates{pullRequestTitleTemplate: "[Feature] %s %d hello"}}, tech: []coreutils.Technology{coreutils.Yarn, coreutils.Go, coreutils.Npm}, expected: "[Feature] hello - Yarn,Go,npm Dependencies"},
+		{gm: defaultGm, tech: []coreutils.Technology{coreutils.Maven}, expected: "[🐸 Frogbot] Update master Maven dependencies"},
+		{gm: defaultGm, tech: []coreutils.Technology{coreutils.Gradle}, expected: "[🐸 Frogbot] Update master Gradle dependencies"},
+		{gm: defaultGm, tech: []coreutils.Technology{coreutils.Npm}, expected: "[🐸 Frogbot] Update master npm dependencies"},
+		{gm: defaultGm, tech: []coreutils.Technology{coreutils.Yarn}, expected: "[🐸 Frogbot] Update master Yarn dependencies"},
+		{gm: GitManager{customTemplates: CustomTemplates{pullRequestTitleTemplate: "[Dependencies] My template "}}, tech: []coreutils.Technology{coreutils.Yarn}, expected: "[Dependencies] My template - master Yarn Dependencies"},
+		{gm: GitManager{customTemplates: CustomTemplates{pullRequestTitleTemplate: ""}}, tech: []coreutils.Technology{coreutils.Yarn}, expected: "[🐸 Frogbot] Update master Yarn dependencies"},
+		{gm: GitManager{customTemplates: CustomTemplates{pullRequestTitleTemplate: "[Feature] %s hello"}}, tech: []coreutils.Technology{coreutils.Yarn}, expected: "[Feature] hello - master Yarn Dependencies"},
+		{gm: GitManager{customTemplates: CustomTemplates{pullRequestTitleTemplate: "[Feature] %s %d hello"}}, tech: []coreutils.Technology{coreutils.Yarn}, expected: "[Feature] hello - master Yarn Dependencies"},
+		{gm: GitManager{customTemplates: CustomTemplates{pullRequestTitleTemplate: "[Feature] %s %d hello"}}, tech: []coreutils.Technology{coreutils.Yarn}, expected: "[Feature] hello - master Yarn Dependencies"},
+		{gm: GitManager{customTemplates: CustomTemplates{pullRequestTitleTemplate: "[Feature] %s %f hello"}}, tech: []coreutils.Technology{coreutils.Yarn, coreutils.Go}, expected: "[Feature] hello - master Yarn,Go Dependencies"},
+		{gm: GitManager{customTemplates: CustomTemplates{pullRequestTitleTemplate: "[Feature] %s %d hello"}}, tech: []coreutils.Technology{coreutils.Yarn, coreutils.Go, coreutils.Npm}, expected: "[Feature] hello - master Yarn,Go,npm Dependencies"},
 		{gm: GitManager{customTemplates: CustomTemplates{pullRequestTitleTemplate: "[Feature] %s %d hello"}}, tech: []coreutils.Technology{}, expected: "[Feature] hello"},
 	}
 	for _, test := range testsCases {
 		t.Run(test.expected, func(t *testing.T) {
-			title := test.gm.GenerateAggregatedPullRequestTitle(test.tech)
+			sourceBranch := "master"
+			title := test.gm.GenerateAggregatedPullRequestTitle(sourceBranch, test.tech)
 			assert.Equal(t, test.expected, title)
 		})
 	}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/frogbot#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
---

### Aggregate Fixes by target branch

Currently there can be only one aggregated fixes PR open for each repository at all times. 

After the change, which is adding the target branch into the branch name it will allow
for each branch that is being scanned in `scan-repository` branches to have it's own aggregated PR.

## Main Changes:

- Add base branch to branch name + title ( only aggregate mode )
- This will cause pull requests duplications for existing users. 
