### PR TITLE
Blocking NPM auto-install in frogbot + Passing forward install command args

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -121,4 +121,4 @@ require (
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 )
 
-replace github.com/jfrog/jfrog-cli-core/v2 => github.com/jfrog/jfrog-cli-core/v2 v2.31.1-0.20231022135540-8a053f99f103
+replace github.com/jfrog/jfrog-cli-core/v2 => github.com/eranturgeman/jfrog-cli-core/v2 v2.0.0-20231029123738-b6dd0b0b79f2

--- a/go.mod
+++ b/go.mod
@@ -123,6 +123,6 @@ require (
 
 //replace github.com/jfrog/jfrog-cli-core/v2 => github.com/eranturgeman/jfrog-cli-core/v2 v2.0.0-20231029123738-b6dd0b0b79f2
 
-replace github.com/jfrog/jfrog-cli-core/v2 => github.com/eranturgeman/jfrog-cli-core/v2 v2.0.0-20231029123738-b6dd0b0b79f2
+replace github.com/jfrog/jfrog-cli-core/v2 => github.com/eranturgeman/jfrog-cli-core/v2 v2.0.0-20231031110817-7e9270ad9354
 
 replace github.com/jfrog/build-info-go => github.com/eranturgeman/build-info-go v0.0.0-20231026150746-66c0ccd91569

--- a/go.mod
+++ b/go.mod
@@ -123,6 +123,6 @@ require (
 
 //replace github.com/jfrog/jfrog-cli-core/v2 => github.com/eranturgeman/jfrog-cli-core/v2 v2.0.0-20231029123738-b6dd0b0b79f2
 
-replace github.com/jfrog/jfrog-cli-core/v2 => github.com/eranturgeman/jfrog-cli-core/v2 v2.0.0-20231031110817-7e9270ad9354
+replace github.com/jfrog/jfrog-cli-core/v2 => github.com/eranturgeman/jfrog-cli-core/v2 v2.0.0-20231031135702-7096b2a93305
 
-replace github.com/jfrog/build-info-go => github.com/eranturgeman/build-info-go v0.0.0-20231026150746-66c0ccd91569
+replace github.com/jfrog/build-info-go => github.com/eranturgeman/build-info-go v0.0.0-20231031133929-fe2b56c06f87

--- a/go.mod
+++ b/go.mod
@@ -121,4 +121,8 @@ require (
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 )
 
+//replace github.com/jfrog/jfrog-cli-core/v2 => github.com/eranturgeman/jfrog-cli-core/v2 v2.0.0-20231029123738-b6dd0b0b79f2
+
 replace github.com/jfrog/jfrog-cli-core/v2 => github.com/eranturgeman/jfrog-cli-core/v2 v2.0.0-20231029123738-b6dd0b0b79f2
+
+replace github.com/jfrog/build-info-go => github.com/eranturgeman/build-info-go v0.0.0-20231026150746-66c0ccd91569

--- a/go.mod
+++ b/go.mod
@@ -121,8 +121,6 @@ require (
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 )
 
-//replace github.com/jfrog/jfrog-cli-core/v2 => github.com/eranturgeman/jfrog-cli-core/v2 v2.0.0-20231029123738-b6dd0b0b79f2
+replace github.com/jfrog/jfrog-cli-core/v2 => github.com/jfrog/jfrog-cli-core/v2 v2.31.1-0.20231031151842-e2f7d850ce11
 
-replace github.com/jfrog/jfrog-cli-core/v2 => github.com/eranturgeman/jfrog-cli-core/v2 v2.0.0-20231031135702-7096b2a93305
-
-replace github.com/jfrog/build-info-go => github.com/eranturgeman/build-info-go v0.0.0-20231031133929-fe2b56c06f87
+replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go v1.8.9-0.20231031143744-13f94ab07bbc

--- a/go.sum
+++ b/go.sum
@@ -703,6 +703,8 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/envoyproxy/protoc-gen-validate v0.6.7/go.mod h1:dyJXwwfPK2VSqiB9Klm1J6romD608Ba7Hij42vrOBCo=
 github.com/envoyproxy/protoc-gen-validate v0.9.1/go.mod h1:OKNgG7TCp5pF4d6XftA0++PMirau2/yoOwVac3AbF2w=
 github.com/envoyproxy/protoc-gen-validate v0.10.0/go.mod h1:DRjgyB0I43LtJapqN6NiRwroiAU2PaFuvk/vjgh61ss=
+github.com/eranturgeman/build-info-go v0.0.0-20231026150746-66c0ccd91569 h1:omtmEOYadgrcOe1plcsy/xL7sjejmAQzpQ61EurAzQY=
+github.com/eranturgeman/build-info-go v0.0.0-20231026150746-66c0ccd91569/go.mod h1:ujJ8XQZMdT2tMkLSMJNyDd1pCY+duwHdjV+9or9FLIg=
 github.com/eranturgeman/jfrog-cli-core/v2 v2.0.0-20231029123738-b6dd0b0b79f2 h1:+SCEJ0wh5nlc2ONYE2+SXq32SbQwMWHsRP9/AvJwOzQ=
 github.com/eranturgeman/jfrog-cli-core/v2 v2.0.0-20231029123738-b6dd0b0b79f2/go.mod h1:eKzmgYirU1D/F9amXkzqHheBeQCuK2akXiskjaaIoPc=
 github.com/fatih/color v1.14.1 h1:qfhVLaG5s+nCROl1zJsZRxFeYrHLqWroPOQ8BWiNb4w=
@@ -880,8 +882,6 @@ github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOl
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jedib0t/go-pretty/v6 v6.4.8 h1:HiNzyMSEpsBaduKhmK+CwcpulEeBrTmxutz4oX/oWkg=
 github.com/jedib0t/go-pretty/v6 v6.4.8/go.mod h1:Ndk3ase2CkQbXLLNf5QDHoYb6J9WtVfmHZu9n8rk2xs=
-github.com/jfrog/build-info-go v1.9.14 h1:xVezJ16Vpm/boRBn3lI1THCQmkylm+6R4zYWxOQ0NSM=
-github.com/jfrog/build-info-go v1.9.14/go.mod h1:ujJ8XQZMdT2tMkLSMJNyDd1pCY+duwHdjV+9or9FLIg=
 github.com/jfrog/froggit-go v1.14.2 h1:55x1anQtaiARlSBMVT59aFU6Mmx90tpcvvAuuPsZm9c=
 github.com/jfrog/froggit-go v1.14.2/go.mod h1:0jRAaZZusaFFnITosmx6CA60SKryuoaCasJyUrP/c1s=
 github.com/jfrog/gofrog v1.3.1 h1:QqAwQXCVReT724uga1AYqG/ZyrNQ6f+iTxmzkb+YFQk=

--- a/go.sum
+++ b/go.sum
@@ -703,6 +703,8 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/envoyproxy/protoc-gen-validate v0.6.7/go.mod h1:dyJXwwfPK2VSqiB9Klm1J6romD608Ba7Hij42vrOBCo=
 github.com/envoyproxy/protoc-gen-validate v0.9.1/go.mod h1:OKNgG7TCp5pF4d6XftA0++PMirau2/yoOwVac3AbF2w=
 github.com/envoyproxy/protoc-gen-validate v0.10.0/go.mod h1:DRjgyB0I43LtJapqN6NiRwroiAU2PaFuvk/vjgh61ss=
+github.com/eranturgeman/jfrog-cli-core/v2 v2.0.0-20231029123738-b6dd0b0b79f2 h1:+SCEJ0wh5nlc2ONYE2+SXq32SbQwMWHsRP9/AvJwOzQ=
+github.com/eranturgeman/jfrog-cli-core/v2 v2.0.0-20231029123738-b6dd0b0b79f2/go.mod h1:eKzmgYirU1D/F9amXkzqHheBeQCuK2akXiskjaaIoPc=
 github.com/fatih/color v1.14.1 h1:qfhVLaG5s+nCROl1zJsZRxFeYrHLqWroPOQ8BWiNb4w=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/fogleman/gg v1.3.0/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
@@ -886,8 +888,6 @@ github.com/jfrog/gofrog v1.3.1 h1:QqAwQXCVReT724uga1AYqG/ZyrNQ6f+iTxmzkb+YFQk=
 github.com/jfrog/gofrog v1.3.1/go.mod h1:IFMc+V/yf7rA5WZ74CSbXe+Lgf0iApEQLxRZVzKRUR0=
 github.com/jfrog/jfrog-apps-config v1.0.1 h1:mtv6k7g8A8BVhlHGlSveapqf4mJfonwvXYLipdsOFMY=
 github.com/jfrog/jfrog-apps-config v1.0.1/go.mod h1:8AIIr1oY9JuH5dylz2S6f8Ym2MaadPLR6noCBO4C22w=
-github.com/jfrog/jfrog-cli-core/v2 v2.31.1-0.20231022135540-8a053f99f103 h1:3Oljo49Dt5vtSRCPRkjYSWpmOkWaar32wjKTP60EgAs=
-github.com/jfrog/jfrog-cli-core/v2 v2.31.1-0.20231022135540-8a053f99f103/go.mod h1:5rTYHinkg5k2ALHYROR3AnE2mMQ22SFZF5dwew1sgco=
 github.com/jfrog/jfrog-client-go v1.34.3 h1:kDfw3FUQQvOsTKFqonIgLlziez6CSX80xCYZIH9YYcg=
 github.com/jfrog/jfrog-client-go v1.34.3/go.mod h1:fuxhYzWEkA16+ZV5cP/BJUGjA3SXVKbBoDmb8ZS6J4g=
 github.com/jordan-wright/email v4.0.1-0.20210109023952-943e75fe5223+incompatible h1:jdpOPRN1zP63Td1hDQbZW73xKmzDvZHzVdNYxhnTMDA=

--- a/go.sum
+++ b/go.sum
@@ -703,10 +703,10 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/envoyproxy/protoc-gen-validate v0.6.7/go.mod h1:dyJXwwfPK2VSqiB9Klm1J6romD608Ba7Hij42vrOBCo=
 github.com/envoyproxy/protoc-gen-validate v0.9.1/go.mod h1:OKNgG7TCp5pF4d6XftA0++PMirau2/yoOwVac3AbF2w=
 github.com/envoyproxy/protoc-gen-validate v0.10.0/go.mod h1:DRjgyB0I43LtJapqN6NiRwroiAU2PaFuvk/vjgh61ss=
-github.com/eranturgeman/build-info-go v0.0.0-20231026150746-66c0ccd91569 h1:omtmEOYadgrcOe1plcsy/xL7sjejmAQzpQ61EurAzQY=
-github.com/eranturgeman/build-info-go v0.0.0-20231026150746-66c0ccd91569/go.mod h1:ujJ8XQZMdT2tMkLSMJNyDd1pCY+duwHdjV+9or9FLIg=
-github.com/eranturgeman/jfrog-cli-core/v2 v2.0.0-20231031110817-7e9270ad9354 h1:PYtG0w3V1eGik79yV29rYodyyMNR12DuL5r0OCeW7HI=
-github.com/eranturgeman/jfrog-cli-core/v2 v2.0.0-20231031110817-7e9270ad9354/go.mod h1:eKzmgYirU1D/F9amXkzqHheBeQCuK2akXiskjaaIoPc=
+github.com/eranturgeman/build-info-go v0.0.0-20231031133929-fe2b56c06f87 h1:TpKRehaI4PoWzegRD6AzpFmLcxoA3SljlUVDgdxzS1A=
+github.com/eranturgeman/build-info-go v0.0.0-20231031133929-fe2b56c06f87/go.mod h1:ujJ8XQZMdT2tMkLSMJNyDd1pCY+duwHdjV+9or9FLIg=
+github.com/eranturgeman/jfrog-cli-core/v2 v2.0.0-20231031135702-7096b2a93305 h1:Ou0WS5Maqq3Cn6oHcoUckbU4HZ7v0GMYUZZD745BlJ4=
+github.com/eranturgeman/jfrog-cli-core/v2 v2.0.0-20231031135702-7096b2a93305/go.mod h1:EF9Rl8DNvHcr2GZt5uUhpepH63fAv43G3B9aCZWSk9s=
 github.com/fatih/color v1.14.1 h1:qfhVLaG5s+nCROl1zJsZRxFeYrHLqWroPOQ8BWiNb4w=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/fogleman/gg v1.3.0/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=

--- a/go.sum
+++ b/go.sum
@@ -703,10 +703,6 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/envoyproxy/protoc-gen-validate v0.6.7/go.mod h1:dyJXwwfPK2VSqiB9Klm1J6romD608Ba7Hij42vrOBCo=
 github.com/envoyproxy/protoc-gen-validate v0.9.1/go.mod h1:OKNgG7TCp5pF4d6XftA0++PMirau2/yoOwVac3AbF2w=
 github.com/envoyproxy/protoc-gen-validate v0.10.0/go.mod h1:DRjgyB0I43LtJapqN6NiRwroiAU2PaFuvk/vjgh61ss=
-github.com/eranturgeman/build-info-go v0.0.0-20231031133929-fe2b56c06f87 h1:TpKRehaI4PoWzegRD6AzpFmLcxoA3SljlUVDgdxzS1A=
-github.com/eranturgeman/build-info-go v0.0.0-20231031133929-fe2b56c06f87/go.mod h1:ujJ8XQZMdT2tMkLSMJNyDd1pCY+duwHdjV+9or9FLIg=
-github.com/eranturgeman/jfrog-cli-core/v2 v2.0.0-20231031135702-7096b2a93305 h1:Ou0WS5Maqq3Cn6oHcoUckbU4HZ7v0GMYUZZD745BlJ4=
-github.com/eranturgeman/jfrog-cli-core/v2 v2.0.0-20231031135702-7096b2a93305/go.mod h1:EF9Rl8DNvHcr2GZt5uUhpepH63fAv43G3B9aCZWSk9s=
 github.com/fatih/color v1.14.1 h1:qfhVLaG5s+nCROl1zJsZRxFeYrHLqWroPOQ8BWiNb4w=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/fogleman/gg v1.3.0/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
@@ -882,12 +878,16 @@ github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOl
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jedib0t/go-pretty/v6 v6.4.8 h1:HiNzyMSEpsBaduKhmK+CwcpulEeBrTmxutz4oX/oWkg=
 github.com/jedib0t/go-pretty/v6 v6.4.8/go.mod h1:Ndk3ase2CkQbXLLNf5QDHoYb6J9WtVfmHZu9n8rk2xs=
+github.com/jfrog/build-info-go v1.8.9-0.20231031143744-13f94ab07bbc h1:MFejgCB90z7nA/KP48lF1t04tYuXAAQc53cBaFd9zcw=
+github.com/jfrog/build-info-go v1.8.9-0.20231031143744-13f94ab07bbc/go.mod h1:ujJ8XQZMdT2tMkLSMJNyDd1pCY+duwHdjV+9or9FLIg=
 github.com/jfrog/froggit-go v1.14.2 h1:55x1anQtaiARlSBMVT59aFU6Mmx90tpcvvAuuPsZm9c=
 github.com/jfrog/froggit-go v1.14.2/go.mod h1:0jRAaZZusaFFnITosmx6CA60SKryuoaCasJyUrP/c1s=
 github.com/jfrog/gofrog v1.3.1 h1:QqAwQXCVReT724uga1AYqG/ZyrNQ6f+iTxmzkb+YFQk=
 github.com/jfrog/gofrog v1.3.1/go.mod h1:IFMc+V/yf7rA5WZ74CSbXe+Lgf0iApEQLxRZVzKRUR0=
 github.com/jfrog/jfrog-apps-config v1.0.1 h1:mtv6k7g8A8BVhlHGlSveapqf4mJfonwvXYLipdsOFMY=
 github.com/jfrog/jfrog-apps-config v1.0.1/go.mod h1:8AIIr1oY9JuH5dylz2S6f8Ym2MaadPLR6noCBO4C22w=
+github.com/jfrog/jfrog-cli-core/v2 v2.31.1-0.20231031151842-e2f7d850ce11 h1:qOR/T+8u6/AQOHCR8x9/41a26SOwfHgLuJX2qNPUrr4=
+github.com/jfrog/jfrog-cli-core/v2 v2.31.1-0.20231031151842-e2f7d850ce11/go.mod h1:NuupJonHkjQzjK63uV6p8RrD+Sv40hZbRghSnrsLd9E=
 github.com/jfrog/jfrog-client-go v1.34.3 h1:kDfw3FUQQvOsTKFqonIgLlziez6CSX80xCYZIH9YYcg=
 github.com/jfrog/jfrog-client-go v1.34.3/go.mod h1:fuxhYzWEkA16+ZV5cP/BJUGjA3SXVKbBoDmb8ZS6J4g=
 github.com/jordan-wright/email v4.0.1-0.20210109023952-943e75fe5223+incompatible h1:jdpOPRN1zP63Td1hDQbZW73xKmzDvZHzVdNYxhnTMDA=

--- a/go.sum
+++ b/go.sum
@@ -705,8 +705,8 @@ github.com/envoyproxy/protoc-gen-validate v0.9.1/go.mod h1:OKNgG7TCp5pF4d6XftA0+
 github.com/envoyproxy/protoc-gen-validate v0.10.0/go.mod h1:DRjgyB0I43LtJapqN6NiRwroiAU2PaFuvk/vjgh61ss=
 github.com/eranturgeman/build-info-go v0.0.0-20231026150746-66c0ccd91569 h1:omtmEOYadgrcOe1plcsy/xL7sjejmAQzpQ61EurAzQY=
 github.com/eranturgeman/build-info-go v0.0.0-20231026150746-66c0ccd91569/go.mod h1:ujJ8XQZMdT2tMkLSMJNyDd1pCY+duwHdjV+9or9FLIg=
-github.com/eranturgeman/jfrog-cli-core/v2 v2.0.0-20231029123738-b6dd0b0b79f2 h1:+SCEJ0wh5nlc2ONYE2+SXq32SbQwMWHsRP9/AvJwOzQ=
-github.com/eranturgeman/jfrog-cli-core/v2 v2.0.0-20231029123738-b6dd0b0b79f2/go.mod h1:eKzmgYirU1D/F9amXkzqHheBeQCuK2akXiskjaaIoPc=
+github.com/eranturgeman/jfrog-cli-core/v2 v2.0.0-20231031110817-7e9270ad9354 h1:PYtG0w3V1eGik79yV29rYodyyMNR12DuL5r0OCeW7HI=
+github.com/eranturgeman/jfrog-cli-core/v2 v2.0.0-20231031110817-7e9270ad9354/go.mod h1:eKzmgYirU1D/F9amXkzqHheBeQCuK2akXiskjaaIoPc=
 github.com/fatih/color v1.14.1 h1:qfhVLaG5s+nCROl1zJsZRxFeYrHLqWroPOQ8BWiNb4w=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/fogleman/gg v1.3.0/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=

--- a/utils/scandetails.go
+++ b/utils/scandetails.go
@@ -142,7 +142,7 @@ func (sc *ScanDetails) RunInstallAndAudit(workDirs ...string) (auditResults *aud
 }
 
 func (sc *ScanDetails) runInstallIfNeeded(workDir string) (err error) {
-	// Temporary block until all 'install' logic moves out from frogbot and this code will be deprecated
+	// A temporary barrier until all the 'install' logic is relocated from frogbot, at which point this code will become obsolete
 	if sc.InstallCommandName == "npm" {
 		return nil
 	}

--- a/utils/scandetails.go
+++ b/utils/scandetails.go
@@ -10,7 +10,6 @@ import (
 	xrayutils "github.com/jfrog/jfrog-cli-core/v2/xray/utils"
 	"github.com/jfrog/jfrog-client-go/utils/log"
 	"github.com/jfrog/jfrog-client-go/xray/services"
-
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -125,7 +124,8 @@ func (sc *ScanDetails) RunInstallAndAudit(workDirs ...string) (auditResults *aud
 		SetUseWrapper(*sc.UseWrapper).
 		SetDepsRepo(sc.DepsRepo).
 		SetIgnoreConfigFile(true).
-		SetServerDetails(sc.ServerDetails)
+		SetServerDetails(sc.ServerDetails).
+		SetInstallCommandArgs(sc.InstallCommandArgs)
 
 	auditParams := audit.NewAuditParams().
 		SetXrayGraphScanParams(sc.XrayGraphScanParams).
@@ -142,6 +142,11 @@ func (sc *ScanDetails) RunInstallAndAudit(workDirs ...string) (auditResults *aud
 }
 
 func (sc *ScanDetails) runInstallIfNeeded(workDir string) (err error) {
+	// Temporary block until all 'install' logic moves out from frogbot and this code will be deprecated
+	if sc.InstallCommandName == "npm" {
+		return nil
+	}
+
 	if sc.InstallCommandName == "" {
 		return nil
 	}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/frogbot#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
---

The transition of all auto-install functions from frogbot to jfrog-cli-core is in progress. Presently, auto-install for NPM is halted, and the install command parameters are forwarded within the process.

Depends on:
https://github.com/jfrog/build-info-go/pull/207
https://github.com/jfrog/jfrog-cli-core/pull/1011
