### PR TITLE
Fix Frogbot schema tests

### DIFF
--- a/schema/schemas_test.go
+++ b/schema/schemas_test.go
@@ -27,8 +27,8 @@ func TestFrogbotSchema(t *testing.T) {
 	assert.NoError(t, err)
 	schemaLoader := gojsonschema.NewBytesLoader(schema)
 
-	// Validate config in the docs
-	validateYamlSchema(t, schemaLoader, filepath.Join("..", "docs", "templates", ".frogbot", "frogbot-config.yml"), "")
+	// Validate config in this repository
+	validateYamlSchema(t, schemaLoader, filepath.Join("..", ".frogbot", "frogbot-config.yml"), "")
 
 	// Validate all frogbot configs in commands/testdata/config
 	validateYamlsInDirectory(t, filepath.Join("..", "testdata", "config"), schemaLoader)
@@ -59,11 +59,6 @@ func TestBadFrogbotSchemas(t *testing.T) {
 func TestJFrogPipelinesTemplates(t *testing.T) {
 	schemaLoader := downloadFromSchemaStore(t, "jfrog-pipelines.json")
 	validateYamlsInDirectory(t, filepath.Join("..", "docs", "templates", "jfrog-pipelines"), schemaLoader)
-}
-
-func TestGitHubActionsTemplates(t *testing.T) {
-	schemaLoader := downloadFromSchemaStore(t, "github-workflow.json")
-	validateYamlsInDirectory(t, filepath.Join("..", "docs", "templates", "github-actions"), schemaLoader)
 }
 
 // Download a Yaml schema from https://json.schemastore.org.


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/frogbot#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
---

Fix broken tests caused by https://github.com/jfrog/frogbot/pull/568.

* Remove GitHub Actions tests - they moved to here: https://github.com/jfrog/documentation/blob/main/jfrog-applications/frogbot/templates/templates_test.go
* The frogbot-config.yml template has been moved to the `jfrog/documentation` repository. Validate the `frogbot-config.yml` of the `jfrog/frogbot` repository instead.