### PR TITLE
Scan repository - show license violation on Github security issues

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -118,7 +118,7 @@ require (
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 )
 
-replace github.com/jfrog/jfrog-cli-core/v2 => github.com/attiasas/jfrog-cli-core/v2 v2.0.0-20231114093618-2ea5c792c4b8
+replace github.com/jfrog/jfrog-cli-core/v2 => github.com/attiasas/jfrog-cli-core/v2 v2.0.0-20231115073337-4f7f8bd09286
 
 // replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go dev
 

--- a/go.mod
+++ b/go.mod
@@ -118,7 +118,7 @@ require (
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 )
 
-// replace github.com/jfrog/jfrog-cli-core/v2 => github.com/jfrog/jfrog-cli-core/v2 dev
+replace github.com/jfrog/jfrog-cli-core/v2 => github.com/attiasas/jfrog-cli-core/v2 v2.0.0-20231114093618-2ea5c792c4b8
 
 // replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go dev
 

--- a/go.mod
+++ b/go.mod
@@ -118,7 +118,7 @@ require (
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 )
 
-replace github.com/jfrog/jfrog-cli-core/v2 => github.com/attiasas/jfrog-cli-core/v2 v2.0.0-20231115073337-4f7f8bd09286
+replace github.com/jfrog/jfrog-cli-core/v2 => github.com/jfrog/jfrog-cli-core/v2 v2.31.1-0.20231116090104-b0db3e222bbd
 
 // replace github.com/jfrog/build-info-go => github.com/jfrog/build-info-go dev
 

--- a/go.sum
+++ b/go.sum
@@ -628,8 +628,8 @@ github.com/apache/arrow/go/v11 v11.0.0/go.mod h1:Eg5OsL5H+e299f7u5ssuXsuHQVEGC4x
 github.com/apache/thrift v0.16.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2FXSqgU=
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
-github.com/attiasas/jfrog-cli-core/v2 v2.0.0-20231114093618-2ea5c792c4b8 h1:DVQpF8PCdX0BYLMcLmuLQYpXadHMgjd9mgg05l+oLqI=
-github.com/attiasas/jfrog-cli-core/v2 v2.0.0-20231114093618-2ea5c792c4b8/go.mod h1:S+KpcxVw9O3jY1KtzvbFtnejinc4GgbykQNhLLtfR8I=
+github.com/attiasas/jfrog-cli-core/v2 v2.0.0-20231115073337-4f7f8bd09286 h1:E8qik0V6ICLnNQUHbEkPaNwn0mlxAdhDq72yFjxwPKU=
+github.com/attiasas/jfrog-cli-core/v2 v2.0.0-20231115073337-4f7f8bd09286/go.mod h1:S+KpcxVw9O3jY1KtzvbFtnejinc4GgbykQNhLLtfR8I=
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/boombuler/barcode v1.0.1/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0 h1:any4BmKE+jGIaMpnU8YgH/I2LPiLBufr6oMMlVBbn9M=

--- a/go.sum
+++ b/go.sum
@@ -628,8 +628,6 @@ github.com/apache/arrow/go/v11 v11.0.0/go.mod h1:Eg5OsL5H+e299f7u5ssuXsuHQVEGC4x
 github.com/apache/thrift v0.16.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2FXSqgU=
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
-github.com/attiasas/jfrog-cli-core/v2 v2.0.0-20231115073337-4f7f8bd09286 h1:E8qik0V6ICLnNQUHbEkPaNwn0mlxAdhDq72yFjxwPKU=
-github.com/attiasas/jfrog-cli-core/v2 v2.0.0-20231115073337-4f7f8bd09286/go.mod h1:S+KpcxVw9O3jY1KtzvbFtnejinc4GgbykQNhLLtfR8I=
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/boombuler/barcode v1.0.1/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0 h1:any4BmKE+jGIaMpnU8YgH/I2LPiLBufr6oMMlVBbn9M=
@@ -884,6 +882,8 @@ github.com/jfrog/gofrog v1.3.1 h1:QqAwQXCVReT724uga1AYqG/ZyrNQ6f+iTxmzkb+YFQk=
 github.com/jfrog/gofrog v1.3.1/go.mod h1:IFMc+V/yf7rA5WZ74CSbXe+Lgf0iApEQLxRZVzKRUR0=
 github.com/jfrog/jfrog-apps-config v1.0.1 h1:mtv6k7g8A8BVhlHGlSveapqf4mJfonwvXYLipdsOFMY=
 github.com/jfrog/jfrog-apps-config v1.0.1/go.mod h1:8AIIr1oY9JuH5dylz2S6f8Ym2MaadPLR6noCBO4C22w=
+github.com/jfrog/jfrog-cli-core/v2 v2.31.1-0.20231116090104-b0db3e222bbd h1:Di+2QuXw5C3pbjVMkfmAy0vf9CJjsJKvHR4W0LUIwgg=
+github.com/jfrog/jfrog-cli-core/v2 v2.31.1-0.20231116090104-b0db3e222bbd/go.mod h1:S+KpcxVw9O3jY1KtzvbFtnejinc4GgbykQNhLLtfR8I=
 github.com/jfrog/jfrog-client-go v1.34.5 h1:NYZrOHvT5D5BwwHdArIz5WnbP+DPbADjV/SPdN33bfQ=
 github.com/jfrog/jfrog-client-go v1.34.5/go.mod h1:0PVhP6xGvBBaUzOU9LKf5OYkke/gY2IFILHA++iabFM=
 github.com/jordan-wright/email v4.0.1-0.20210109023952-943e75fe5223+incompatible h1:jdpOPRN1zP63Td1hDQbZW73xKmzDvZHzVdNYxhnTMDA=

--- a/go.sum
+++ b/go.sum
@@ -628,6 +628,8 @@ github.com/apache/arrow/go/v11 v11.0.0/go.mod h1:Eg5OsL5H+e299f7u5ssuXsuHQVEGC4x
 github.com/apache/thrift v0.16.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2FXSqgU=
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
+github.com/attiasas/jfrog-cli-core/v2 v2.0.0-20231114093618-2ea5c792c4b8 h1:DVQpF8PCdX0BYLMcLmuLQYpXadHMgjd9mgg05l+oLqI=
+github.com/attiasas/jfrog-cli-core/v2 v2.0.0-20231114093618-2ea5c792c4b8/go.mod h1:S+KpcxVw9O3jY1KtzvbFtnejinc4GgbykQNhLLtfR8I=
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/boombuler/barcode v1.0.1/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0 h1:any4BmKE+jGIaMpnU8YgH/I2LPiLBufr6oMMlVBbn9M=
@@ -882,8 +884,6 @@ github.com/jfrog/gofrog v1.3.1 h1:QqAwQXCVReT724uga1AYqG/ZyrNQ6f+iTxmzkb+YFQk=
 github.com/jfrog/gofrog v1.3.1/go.mod h1:IFMc+V/yf7rA5WZ74CSbXe+Lgf0iApEQLxRZVzKRUR0=
 github.com/jfrog/jfrog-apps-config v1.0.1 h1:mtv6k7g8A8BVhlHGlSveapqf4mJfonwvXYLipdsOFMY=
 github.com/jfrog/jfrog-apps-config v1.0.1/go.mod h1:8AIIr1oY9JuH5dylz2S6f8Ym2MaadPLR6noCBO4C22w=
-github.com/jfrog/jfrog-cli-core/v2 v2.46.1 h1:4bkyykJk9OUJFXW44NmYGlOmhu6HVG43KUtY5p/wsQA=
-github.com/jfrog/jfrog-cli-core/v2 v2.46.1/go.mod h1:S+KpcxVw9O3jY1KtzvbFtnejinc4GgbykQNhLLtfR8I=
 github.com/jfrog/jfrog-client-go v1.34.5 h1:NYZrOHvT5D5BwwHdArIz5WnbP+DPbADjV/SPdN33bfQ=
 github.com/jfrog/jfrog-client-go v1.34.5/go.mod h1:0PVhP6xGvBBaUzOU9LKf5OYkke/gY2IFILHA++iabFM=
 github.com/jordan-wright/email v4.0.1-0.20210109023952-943e75fe5223+incompatible h1:jdpOPRN1zP63Td1hDQbZW73xKmzDvZHzVdNYxhnTMDA=

--- a/scanpullrequest/scanpullrequest.go
+++ b/scanpullrequest/scanpullrequest.go
@@ -124,7 +124,7 @@ func toFailTaskStatus(repo *utils.Repository, issues *utils.IssuesCollection) bo
 // Downloads Pull Requests branches code and audits them
 func auditPullRequest(repoConfig *utils.Repository, client vcsclient.VcsClient) (issuesCollection *utils.IssuesCollection, err error) {
 	scanDetails := utils.NewScanDetails(client, &repoConfig.Server, &repoConfig.Git).
-		SetXrayGraphScanParams(repoConfig.Watches, repoConfig.JFrogProjectKey, true).
+		SetXrayGraphScanParams(repoConfig.Watches, repoConfig.JFrogProjectKey, len(repoConfig.AllowedLicenses) > 0).
 		SetMinSeverity(repoConfig.MinSeverity).
 		SetFixableOnly(repoConfig.FixableOnly).
 		SetFailOnInstallationErrors(*repoConfig.FailOnSecurityIssues)

--- a/scanpullrequest/scanpullrequest.go
+++ b/scanpullrequest/scanpullrequest.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"os"
 
-	// "golang.org/x/exp/slices"
-
 	"github.com/jfrog/frogbot/utils"
 	"github.com/jfrog/froggit-go/vcsclient"
 	"github.com/jfrog/froggit-go/vcsutils"

--- a/scanpullrequest/scanpullrequest.go
+++ b/scanpullrequest/scanpullrequest.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"os"
 
-	"golang.org/x/exp/slices"
+	// "golang.org/x/exp/slices"
 
 	"github.com/jfrog/frogbot/utils"
 	"github.com/jfrog/froggit-go/vcsclient"
@@ -212,16 +212,16 @@ func auditTargetBranch(repoConfig *utils.Repository, scanDetails *utils.ScanDeta
 func getAllIssues(results *xrayutils.Results, allowedLicenses []string) (*utils.IssuesCollection, error) {
 	log.Info("Frogbot is configured to show all vulnerabilities")
 	scanResults := results.ExtendedScanResults
-	allVulnerabilitiesRows, violatedLicenses, err := getScanVulnerabilitiesRows(results, allowedLicenses)
+	xraySimpleJson, err := xrayutils.ConvertXrayScanToSimpleJson(results, results.IsMultipleProject(), false, true, allowedLicenses)
 	if err != nil {
 		return nil, err
 	}
 	return &utils.IssuesCollection{
-		Vulnerabilities: allVulnerabilitiesRows,
+		Vulnerabilities: append(xraySimpleJson.Vulnerabilities, xraySimpleJson.SecurityViolations...),
 		Iacs:            xrayutils.PrepareIacs(scanResults.IacScanResults),
 		Secrets:         xrayutils.PrepareSecrets(scanResults.SecretsScanResults),
 		Sast:            xrayutils.PrepareSast(scanResults.SastScanResults),
-		Licenses:        violatedLicenses,
+		Licenses:        xraySimpleJson.LicensesViolations,
 	}, nil
 }
 
@@ -297,7 +297,7 @@ func createNewVulnerabilitiesRows(targetResults, sourceResults *xrayutils.Result
 	if newLicenses, err = getNewLicenseRows(&targetScanAggregatedResults, &sourceScanAggregatedResults); err != nil {
 		return
 	}
-	licenseRows = getViolatedLicenses(allowedLicenses, newLicenses)
+	licenseRows = xrayutils.GetViolatedLicenses(allowedLicenses, newLicenses)
 	return
 }
 
@@ -387,40 +387,4 @@ func aggregateScanResults(scanResults []services.ScanResponse) services.ScanResp
 		aggregateResults.Licenses = append(aggregateResults.Licenses, scanResult.Licenses...)
 	}
 	return aggregateResults
-}
-
-// Create vulnerability rows. The rows should contain all the issues that were found in this module scan.
-func getScanVulnerabilitiesRows(auditResults *xrayutils.Results, allowedLicenses []string) (vulnerabilitiesRows []formats.VulnerabilityOrViolationRow, violatedLicenses []formats.LicenseRow, err error) {
-	violations, vulnerabilities, licenses := xrayutils.SplitScanResults(auditResults.ScaResults)
-	if len(violations) > 0 {
-		var licenseViolationsRows []formats.LicenseRow
-		if vulnerabilitiesRows, licenseViolationsRows, _, err = xrayutils.PrepareViolations(violations, auditResults, auditResults.IsMultipleProject(), true); err != nil {
-			return nil, nil, err
-		}
-		return vulnerabilitiesRows, licenseViolationsRows, err
-	}
-	if len(vulnerabilities) > 0 {
-		if vulnerabilitiesRows, err = xrayutils.PrepareVulnerabilities(vulnerabilities, auditResults, auditResults.IsMultipleProject(), true); err != nil {
-			return
-		}
-	}
-	var licenseRows []formats.LicenseRow
-	if licenseRows, err = xrayutils.PrepareLicenses(licenses); err != nil {
-		return
-	}
-	violatedLicenses = getViolatedLicenses(allowedLicenses, licenseRows)
-	return
-}
-
-func getViolatedLicenses(allowedLicenses []string, licenses []formats.LicenseRow) []formats.LicenseRow {
-	if len(allowedLicenses) == 0 {
-		return nil
-	}
-	var violatedLicenses []formats.LicenseRow
-	for _, license := range licenses {
-		if !slices.Contains(allowedLicenses, license.LicenseKey) {
-			violatedLicenses = append(violatedLicenses, license)
-		}
-	}
-	return violatedLicenses
 }

--- a/scanpullrequest/scanpullrequest_test.go
+++ b/scanpullrequest/scanpullrequest_test.go
@@ -220,67 +220,6 @@ func TestGetNewViolationsCaseNoNewViolations(t *testing.T) {
 	assert.Len(t, licenseViolations, 0)
 }
 
-func TestGetAllVulnerabilities(t *testing.T) {
-	// Current scan with 2 vulnerabilities - XRAY-1 and XRAY-2
-	currentScan := services.ScanResponse{
-		Vulnerabilities: []services.Vulnerability{
-			{
-				IssueId:    "XRAY-1",
-				Summary:    "summary-1",
-				Severity:   "high",
-				Components: map[string]services.Component{"component-A": {}, "component-B": {}},
-			},
-			{
-				IssueId:    "XRAY-2",
-				Summary:    "summary-2",
-				Severity:   "low",
-				Components: map[string]services.Component{"component-C": {}, "component-D": {}},
-			},
-		},
-	}
-
-	expected := []formats.VulnerabilityOrViolationRow{
-		{
-			Summary: "summary-1",
-			IssueId: "XRAY-1",
-			ImpactedDependencyDetails: formats.ImpactedDependencyDetails{
-				SeverityDetails:        formats.SeverityDetails{Severity: "high"},
-				ImpactedDependencyName: "component-A",
-			},
-		},
-		{
-			Summary: "summary-1",
-			IssueId: "XRAY-1",
-			ImpactedDependencyDetails: formats.ImpactedDependencyDetails{
-				SeverityDetails:        formats.SeverityDetails{Severity: "high"},
-				ImpactedDependencyName: "component-B",
-			},
-		},
-		{
-			Summary: "summary-2",
-			IssueId: "XRAY-2",
-			ImpactedDependencyDetails: formats.ImpactedDependencyDetails{
-				SeverityDetails:        formats.SeverityDetails{Severity: "low"},
-				ImpactedDependencyName: "component-C",
-			},
-		},
-		{
-			Summary: "summary-2",
-			IssueId: "XRAY-2",
-			ImpactedDependencyDetails: formats.ImpactedDependencyDetails{
-				SeverityDetails:        formats.SeverityDetails{Severity: "low"},
-				ImpactedDependencyName: "component-D",
-			},
-		},
-	}
-	// Run createAllIssuesRows and make sure that XRAY-1 and XRAY-2 vulnerabilities exists in the results
-	vulnerabilities, licenses, err := getScanVulnerabilitiesRows(&xrayutils.Results{ScaResults: []xrayutils.ScaScanResult{xrayutils.ScaScanResult{XrayResults: []services.ScanResponse{currentScan}}}, ExtendedScanResults: &xrayutils.ExtendedScanResults{}}, nil)
-	assert.NoError(t, err)
-	assert.Len(t, vulnerabilities, 4)
-	assert.Len(t, licenses, 0)
-	assert.ElementsMatch(t, expected, vulnerabilities)
-}
-
 func TestGetNewVulnerabilities(t *testing.T) {
 	// Previous scan with only one vulnerability - XRAY-1
 	previousScan := services.ScanResponse{

--- a/scanpullrequest/scanpullrequest_test.go
+++ b/scanpullrequest/scanpullrequest_test.go
@@ -143,6 +143,7 @@ func TestCreateVulnerabilitiesRowsCaseNoPrevViolations(t *testing.T) {
 	expectedVulns := []formats.VulnerabilityOrViolationRow{
 		{
 			IssueId: "XRAY-1",
+			Summary: "summary-1",
 			ImpactedDependencyDetails: formats.ImpactedDependencyDetails{
 				SeverityDetails:        formats.SeverityDetails{Severity: "high"},
 				ImpactedDependencyName: "component-A",
@@ -150,6 +151,7 @@ func TestCreateVulnerabilitiesRowsCaseNoPrevViolations(t *testing.T) {
 		},
 		{
 			IssueId: "XRAY-2",
+			Summary: "summary-2",
 			ImpactedDependencyDetails: formats.ImpactedDependencyDetails{
 				SeverityDetails:        formats.SeverityDetails{Severity: "low"},
 				ImpactedDependencyName: "component-C",

--- a/scanrepository/scanrepository.go
+++ b/scanrepository/scanrepository.go
@@ -91,7 +91,7 @@ func (cfp *ScanRepositoryCmd) scanAndFixBranch(repository *utils.Repository) (er
 
 func (cfp *ScanRepositoryCmd) setCommandPrerequisites(repository *utils.Repository, branch string, client vcsclient.VcsClient) (err error) {
 	cfp.scanDetails = utils.NewScanDetails(client, &repository.Server, &repository.Git).
-		SetXrayGraphScanParams(repository.Watches, repository.JFrogProjectKey, false).
+		SetXrayGraphScanParams(repository.Watches, repository.JFrogProjectKey, len(repository.AllowedLicenses) > 0).
 		SetFailOnInstallationErrors(*repository.FailOnSecurityIssues).
 		SetBaseBranch(branch).
 		SetFixableOnly(repository.FixableOnly).

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -217,7 +217,7 @@ func VulnerabilityDetailsToMD5Hash(vulnerabilities ...formats.VulnerabilityOrVio
 }
 
 func UploadSarifResultsToGithubSecurityTab(scanResults *xrayutils.Results, repo *Repository, branch string, client vcsclient.VcsClient) error {
-	report, err := GenerateFrogbotSarifReport(scanResults, scanResults.IsMultipleProject())
+	report, err := GenerateFrogbotSarifReport(scanResults, scanResults.IsMultipleProject(), repo.AllowedLicenses)
 	if err != nil {
 		return err
 	}
@@ -272,8 +272,8 @@ func convertToRelativePath(runs []*sarif.Run) {
 	}
 }
 
-func GenerateFrogbotSarifReport(extendedResults *xrayutils.Results, isMultipleRoots bool) (string, error) {
-	sarifReport, err := xrayutils.GenereateSarifReportFromResults(extendedResults, isMultipleRoots, false)
+func GenerateFrogbotSarifReport(extendedResults *xrayutils.Results, isMultipleRoots bool, allowedLicenses []string) (string, error) {
+	sarifReport, err := xrayutils.GenereateSarifReportFromResults(extendedResults, isMultipleRoots, false, allowedLicenses)
 	if err != nil {
 		return "", err
 	}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -231,8 +231,6 @@ func UploadSarifResultsToGithubSecurityTab(scanResults *xrayutils.Results, repo 
 
 func prepareRunsForGithubReport(runs []*sarif.Run) []*sarif.Run {
 	for _, run := range runs {
-		// run.Tool.Driver.Name = sarifToolName
-		// run.Tool.Driver.WithInformationURI(outputwriter.FrogbotRepoUrl)
 		for _, rule := range run.Tool.Driver.Rules {
 			// Github security tab can display markdown content on Help attribute and not description
 			if rule.Help == nil && rule.FullDescription != nil {

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -417,8 +417,8 @@ func TestPrepareRunsForGithubReport(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		prepareRunsForGithubReport([]*sarif.Run{tc.run})
-		assert.Equal(t, tc.expectedOutput, tc.run)
+		
+		assert.Equal(t, tc.expectedOutput, prepareRunsForGithubReport([]*sarif.Run{tc.run})[0])
 	}
 }
 

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -417,7 +417,7 @@ func TestPrepareRunsForGithubReport(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		
+
 		assert.Equal(t, tc.expectedOutput, prepareRunsForGithubReport([]*sarif.Run{tc.run})[0])
 	}
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/frogbot#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
---

* Additionally, a bug has been fixed where on Github issues only one run (last) was displayed as an active issues, while the other was considered resolved.

---

depends on: https://github.com/jfrog/jfrog-cli-core/pull/1030

When `watches` are defined, Show license violations with default location `package-descriptor` at Github security issue tab

<img width="954" alt="image" src="https://github.com/jfrog/frogbot/assets/49212512/a57fd136-dbb7-4859-b036-bf3966495fa7">
