### PR TITLE
Add informative errors for the unmarshaling processes in the MavenPackageHandler

### DIFF
--- a/packagehandlers/mavenpackagehandler.go
+++ b/packagehandlers/mavenpackagehandler.go
@@ -112,6 +112,7 @@ func (mph *MavenPackageHandler) fillDependenciesMap(pomPath string) error {
 func getMavenDependencies(pomXmlContent []byte) (result []gavCoordinate, err error) {
 	var dependencies mavenDependency
 	if err = xml.Unmarshal(pomXmlContent, &dependencies); err != nil {
+		err = fmt.Errorf("failed to unmarshal the current pom.xml:\n%s, error received:\n%w"+string(pomXmlContent), err)
 		return
 	}
 	result = append(result, dependencies.collectMavenDependencies(false)...)
@@ -199,6 +200,7 @@ func (mph *MavenPackageHandler) getProjectPoms() (err error) {
 		// Escape backslashes in the pomPath field, to fix windows backslash parsing issues
 		escapedContent := strings.ReplaceAll(jsonContent, `\`, `\\`)
 		if err = json.Unmarshal([]byte(escapedContent), &pp); err != nil {
+			err = fmt.Errorf("failed to unmarshal the maven-dep-tree output. Full maven-dep-tree output:\n%s\nCurrent line:\n%s\nError details:\n%w", string(depTreeOutput), escapedContent, err)
 			return
 		}
 		mph.pomPaths = append(mph.pomPaths, pp)


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/frogbot#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
---
- Add informative errors for the unmarshaling processes in the MavenPackageHandler
- Related to: https://github.com/jfrog/frogbot/issues/587
