### PR TITLE
Fix false positive golangci-linter typecheck error

### DIFF
--- a/scanrepository/scanrepository.go
+++ b/scanrepository/scanrepository.go
@@ -636,7 +636,7 @@ func parseVersionChangeString(fixVersion string) string {
 // Skip build tools dependencies (for example, pip)
 // that are not defined in the descriptor file and cannot be fixed by a PR.
 func isBuildToolsDependency(vulnDetails *utils.VulnerabilityDetails) error {
-	//nolint:typecheck // Ignoring typecheck error: linter cannot infer the type returned by utils.BuildToolsDependenciesMap as []string although utils.BuildToolsDependenciesMap is declared as map[coreutils.Technology][]string in utils/utils.go
+	//nolint:typecheck // Ignoring typecheck error: The linter fails to deduce the returned type as []string from utils.BuildToolsDependenciesMap, despite its declaration in utils/utils.go as map[coreutils.Technology][]string.
 	if slices.Contains(utils.BuildToolsDependenciesMap[vulnDetails.Technology], vulnDetails.ImpactedDependencyName) {
 		return &utils.ErrUnsupportedFix{
 			PackageName:  vulnDetails.ImpactedDependencyName,

--- a/scanrepository/scanrepository.go
+++ b/scanrepository/scanrepository.go
@@ -636,6 +636,7 @@ func parseVersionChangeString(fixVersion string) string {
 // Skip build tools dependencies (for example, pip)
 // that are not defined in the descriptor file and cannot be fixed by a PR.
 func isBuildToolsDependency(vulnDetails *utils.VulnerabilityDetails) error {
+	//nolint:typecheck // Ignoring typecheck error: linter cannot infer the type returned by utils.BuildToolsDependenciesMap as []string although utils.BuildToolsDependenciesMap is declared as map[coreutils.Technology][]string in utils/utils.go
 	if slices.Contains(utils.BuildToolsDependenciesMap[vulnDetails.Technology], vulnDetails.ImpactedDependencyName) {
 		return &utils.ErrUnsupportedFix{
 			PackageName:  vulnDetails.ImpactedDependencyName,


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/frogbot#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
---

Ignoring a typecheck error thrown by linter.
The first argument provided to slice.Contains cannot be inferred as []string type although it is declared correctly in another file