### PR TITLE
Scan fails upon empty PR push

### DIFF
--- a/scanrepository/scanrepository.go
+++ b/scanrepository/scanrepository.go
@@ -276,18 +276,17 @@ func (cfp *ScanRepositoryCmd) fixIssuesSinglePR(vulnerabilitiesMap map[string]ma
 // else, return the error
 func (cfp *ScanRepositoryCmd) handleUpdatePackageErrors(err error) error {
 	var errUnsupportedFix *utils.ErrUnsupportedFix
-	var errNoChangesToCommit *utils.ErrNoChangesToCommit
+	var errNoChangesToCommit *utils.ErrNothingToCommit
 
 	switch {
 	case errors.As(err, &errUnsupportedFix):
 		log.Debug(strings.TrimSpace(err.Error()))
-		return nil
 	case errors.As(err, &errNoChangesToCommit):
 		log.Info(err.Error())
-		return nil
 	default:
 		return err
 	}
+	return nil
 }
 
 // Creates a branch for the fixed package and open pull request against the target branch.
@@ -344,7 +343,7 @@ func (cfp *ScanRepositoryCmd) openFixingPullRequest(fixBranchName string, vulnDe
 	}
 	if isClean {
 		// In instances where a fix is required that Frogbot does not support, the worktree will remain clean, and there will be nothing to push
-		return &utils.ErrNoChangesToCommit{PackageName: vulnDetails.ImpactedDependencyName}
+		return &utils.ErrNothingToCommit{PackageName: vulnDetails.ImpactedDependencyName}
 	}
 	commitMessage := cfp.gitManager.GenerateCommitMessage(vulnDetails.ImpactedDependencyName, vulnDetails.SuggestedFixedVersion)
 	if err = cfp.gitManager.AddAllAndCommit(commitMessage); err != nil {

--- a/scanrepository/scanrepository.go
+++ b/scanrepository/scanrepository.go
@@ -343,7 +343,7 @@ func (cfp *ScanRepositoryCmd) openFixingPullRequest(fixBranchName string, vulnDe
 		return
 	}
 	if isClean {
-		// In some cases there is a fix to perform which Frogbot doesn't support. In this case the worktree will be clean and there is nothing to push
+		// In instances where a fix is required that Frogbot does not support, the worktree will remain clean, and there will be nothing to push
 		return &utils.ErrNoChangesToCommit{PackageName: vulnDetails.ImpactedDependencyName}
 	}
 	commitMessage := cfp.gitManager.GenerateCommitMessage(vulnDetails.ImpactedDependencyName, vulnDetails.SuggestedFixedVersion)

--- a/scanrepository/scanrepository.go
+++ b/scanrepository/scanrepository.go
@@ -194,7 +194,7 @@ func (cfp *ScanRepositoryCmd) fixIssuesSeparatePRs(vulnerabilitiesMap map[string
 	var err error
 	for fullPath, vulnerabilities := range vulnerabilitiesMap {
 		if e := cfp.fixProjectVulnerabilities(fullPath, vulnerabilities); e != nil {
-			err = errors.Join(err, fmt.Errorf("`the following errors occured while fixing vulnerabilities in` %s:\n%s", fullPath, e)) //TODO ERAN step 3 - separate fixes
+			err = errors.Join(err, fmt.Errorf("`the following errors occured while fixing vulnerabilities in` %s:\n%s", fullPath, e))
 		}
 	}
 	return err
@@ -248,7 +248,7 @@ func (cfp *ScanRepositoryCmd) fixMultiplePackages(fullProjectPath string, vulner
 	}
 	for _, vulnDetails := range vulnerabilities {
 		if e := cfp.updatePackageToFixedVersion(vulnDetails); e != nil {
-			err = errors.Join(err, cfp.handleUpdatePackageErrors(e)) //TODO EARN this is a possible fix point for the error
+			err = errors.Join(err, cfp.handleUpdatePackageErrors(e))
 			continue
 		}
 		fixedVulnerabilities = append(fixedVulnerabilities, vulnDetails)
@@ -275,7 +275,6 @@ func (cfp *ScanRepositoryCmd) fixIssuesSinglePR(vulnerabilitiesMap map[string]ma
 // When the expected custom error occurs, log to debug.
 // else, return the error
 func (cfp *ScanRepositoryCmd) handleUpdatePackageErrors(err error) error {
-	//TODO ERAN take care of the error here. define a spacial error for "nothing to commit" and make the error = nil
 	var errUnsupportedFix *utils.ErrUnsupportedFix
 	var errNoChangesToCommit *utils.ErrNoChangesToCommit
 
@@ -289,16 +288,6 @@ func (cfp *ScanRepositoryCmd) handleUpdatePackageErrors(err error) error {
 	default:
 		return err
 	}
-	/*
-		if errors.As(err, &errUnsupportedFix) {
-			log.Debug(strings.TrimSpace(err.Error()))
-			return nil
-		}
-
-
-		return err
-
-	*/
 }
 
 // Creates a branch for the fixed package and open pull request against the target branch.
@@ -341,13 +330,7 @@ func (cfp *ScanRepositoryCmd) fixSinglePackageAndCreatePR(vulnDetails *utils.Vul
 		return
 	}
 	if err = cfp.openFixingPullRequest(fixBranchName, vulnDetails); err != nil {
-		wrapErr := fmt.Errorf("failed while creating a fixing pull request for: %s with version: %s with error: ", vulnDetails.ImpactedDependencyName, fixVersion)
-		return errors.Join(wrapErr, err)
-		/*
-			return fmt.Errorf("failed while creating a fixing pull request for: %s with version: %s with error: \n%s",
-				vulnDetails.ImpactedDependencyName, fixVersion, err.Error()) //TODO ERAN step 2
-
-		*/
+		return errors.Join(fmt.Errorf("failed while creating a fixing pull request for: %s with version: %s with error: ", vulnDetails.ImpactedDependencyName, fixVersion), err)
 	}
 	log.Info(fmt.Sprintf("Created Pull Request updating dependency '%s' to version '%s'", vulnDetails.ImpactedDependencyName, vulnDetails.SuggestedFixedVersion))
 	return
@@ -359,11 +342,9 @@ func (cfp *ScanRepositoryCmd) openFixingPullRequest(fixBranchName string, vulnDe
 	if err != nil {
 		return
 	}
-	//TODO ERAN put this to check bug: isClean = true
 	if isClean {
 		// In some cases there is a fix to perform which Frogbot doesn't support. In this case the worktree will be clean and there is nothing to push
 		return &utils.ErrNoChangesToCommit{PackageName: vulnDetails.ImpactedDependencyName}
-		//return fmt.Errorf("there were no changes to commit after fixing the package '%s'", vulnDetails.ImpactedDependencyName) //TODO ERAN step 1
 	}
 	commitMessage := cfp.gitManager.GenerateCommitMessage(vulnDetails.ImpactedDependencyName, vulnDetails.SuggestedFixedVersion)
 	if err = cfp.gitManager.AddAllAndCommit(commitMessage); err != nil {
@@ -584,7 +565,7 @@ func (cfp *ScanRepositoryCmd) aggregateFixAndOpenPullRequest(vulnerabilitiesMap 
 	for fullPath, vulnerabilities := range vulnerabilitiesMap {
 		currentFixes, e := cfp.fixMultiplePackages(fullPath, vulnerabilities)
 		if e != nil {
-			err = errors.Join(err, fmt.Errorf("the following errors occured while fixing vulnerabilities in %s:\n%s", fullPath, e)) //TODO ERAN step 3 aggregated fix
+			err = errors.Join(err, fmt.Errorf("the following errors occured while fixing vulnerabilities in %s:\n%s", fullPath, e))
 			continue
 		}
 		fixedVulnerabilities = append(fixedVulnerabilities, currentFixes...)

--- a/scanrepository/scanrepository.go
+++ b/scanrepository/scanrepository.go
@@ -194,7 +194,7 @@ func (cfp *ScanRepositoryCmd) fixIssuesSeparatePRs(vulnerabilitiesMap map[string
 	var err error
 	for fullPath, vulnerabilities := range vulnerabilitiesMap {
 		if e := cfp.fixProjectVulnerabilities(fullPath, vulnerabilities); e != nil {
-			err = errors.Join(err, fmt.Errorf("`the following errors occured while fixing vulnerabilities in` %s:\n%s", fullPath, e))
+			err = errors.Join(err, fmt.Errorf("the following errors occured while fixing vulnerabilities in '%s':\n%s", fullPath, e))
 		}
 	}
 	return err

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -68,7 +68,7 @@ type ErrUnsupportedFix struct {
 	ErrorType    UnsupportedErrorType
 }
 
-type ErrNoChangesToCommit struct {
+type ErrNothingToCommit struct {
 	PackageName string
 }
 
@@ -81,7 +81,7 @@ func (err *ErrUnsupportedFix) Error() string {
 	return fmt.Sprintf(skipBuildToolDependencyMsg, err.PackageName, err.PackageName, err.FixedVersion)
 }
 
-func (err *ErrNoChangesToCommit) Error() string {
+func (err *ErrNothingToCommit) Error() string {
 	return fmt.Sprintf("there were no changes to commit after fixing the package '%s'.\n"+
 		"Note: Frogbot currently cannot address certain vulnerabilities in some package managers, which may result in the absence of changes", err.PackageName)
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -68,6 +68,10 @@ type ErrUnsupportedFix struct {
 	ErrorType    UnsupportedErrorType
 }
 
+type ErrNoChangesToCommit struct {
+	PackageName string
+}
+
 // Custom error for unsupported fixes
 // Currently we hold two unsupported reasons, indirect and build tools dependencies.
 func (err *ErrUnsupportedFix) Error() string {
@@ -75,6 +79,11 @@ func (err *ErrUnsupportedFix) Error() string {
 		return fmt.Sprintf(skipIndirectVulnerabilitiesMsg, err.PackageName, err.FixedVersion)
 	}
 	return fmt.Sprintf(skipBuildToolDependencyMsg, err.PackageName, err.PackageName, err.FixedVersion)
+}
+
+func (err *ErrNoChangesToCommit) Error() string {
+	return fmt.Sprintf("there were no changes to commit after fixing the package '%s'.\n"+
+		"Note: Frogbot currently cannot address certain vulnerabilities in some package managers, which may result in the absence of changes", err.PackageName)
 }
 
 // VulnerabilityDetails serves as a container for essential information regarding a vulnerability that is going to be addressed and resolved


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/frogbot#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
---

This PR fixes failure in scan-repository (separate PRs for each vulnerability) when there is nothing to push after the fix in some vulnerability (this can happen when there is no fix branch and Frogbot cannot fix the vulnerability)