### PR TITLE
Fix comments removal & scan-all-PRs iteration bugs

### DIFF
--- a/scanpullrequest/scanallpullrequests.go
+++ b/scanpullrequest/scanallpullrequests.go
@@ -47,7 +47,7 @@ func scanAllPullRequests(repo utils.Repository, client vcsclient.VcsClient) (err
 		}
 		if !shouldScan {
 			log.Info("Pull Request", pr.ID, "has already been scanned before. If you wish to scan it again, please comment \"rescan\".")
-			return
+			continue
 		}
 		repo.PullRequestDetails = pr
 		if e = scanPullRequest(&repo, client); e != nil {

--- a/scanpullrequest/scanallpullrequests.go
+++ b/scanpullrequest/scanallpullrequests.go
@@ -47,7 +47,7 @@ func scanAllPullRequests(repo utils.Repository, client vcsclient.VcsClient) (err
 		}
 		if !shouldScan {
 			log.Info("Pull Request", pr.ID, "has already been scanned before. If you wish to scan it again, please comment \"rescan\".")
-			continue
+			return
 		}
 		repo.PullRequestDetails = pr
 		if e = scanPullRequest(&repo, client); e != nil {

--- a/utils/comment.go
+++ b/utils/comment.go
@@ -41,10 +41,12 @@ func HandlePullRequestCommentsAfterScan(issues *IssuesCollection, repo *Reposito
 		// Delete previous PR regular comments, if exists (not related to location of a change)
 		if err = DeleteExistingPullRequestComments(repo, client); err != nil {
 			log.Error(fmt.Sprintf("%s:\n%v", commentRemovalErrorMsg, err))
+			err = nil
 		}
 		// Delete previous PR review comments, if exists (related to location of a change)
 		if err = DeleteExistingPullRequestReviewComments(repo, pullRequestID, client); err != nil {
 			log.Error(fmt.Sprintf("%s:\n%v", commentRemovalErrorMsg, err))
+			err = nil
 		}
 	}
 

--- a/utils/comment.go
+++ b/utils/comment.go
@@ -39,14 +39,12 @@ func HandlePullRequestCommentsAfterScan(issues *IssuesCollection, repo *Reposito
 		// we will not cause a Frogbot run to fail but will instead log the error.
 		log.Debug("Looking for an existing Frogbot pull request comment. Deleting it if it exists...")
 		// Delete previous PR regular comments, if exists (not related to location of a change)
-		if err = DeleteExistingPullRequestComments(repo, client); err != nil {
-			log.Error(fmt.Sprintf("%s:\n%v", commentRemovalErrorMsg, err))
-			err = nil
+		if e := DeleteExistingPullRequestComments(repo, client); e != nil {
+			log.Error(fmt.Sprintf("%s:\n%v", commentRemovalErrorMsg, e))
 		}
 		// Delete previous PR review comments, if exists (related to location of a change)
-		if err = DeleteExistingPullRequestReviewComments(repo, pullRequestID, client); err != nil {
-			log.Error(fmt.Sprintf("%s:\n%v", commentRemovalErrorMsg, err))
-			err = nil
+		if e := DeleteExistingPullRequestReviewComments(repo, pullRequestID, client); e != nil {
+			log.Error(fmt.Sprintf("%s:\n%v", commentRemovalErrorMsg, e))
 		}
 	}
 

--- a/utils/comment.go
+++ b/utils/comment.go
@@ -41,12 +41,10 @@ func HandlePullRequestCommentsAfterScan(issues *IssuesCollection, repo *Reposito
 		// Delete previous PR regular comments, if exists (not related to location of a change)
 		if err = DeleteExistingPullRequestComments(repo, client); err != nil {
 			log.Error(fmt.Sprintf("%s:\n%v", commentRemovalErrorMsg, err))
-			return
 		}
 		// Delete previous PR review comments, if exists (related to location of a change)
 		if err = DeleteExistingPullRequestReviewComments(repo, pullRequestID, client); err != nil {
 			log.Error(fmt.Sprintf("%s:\n%v", commentRemovalErrorMsg, err))
-			return
 		}
 	}
 


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/frogbot#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
---
This PR resolves 2 bugs:
1) In scan-all-pull-requests when we iterate the open PRs and check for each of them if it should be scanned, we used to return upon the first encounter in a PR that should not be scanned. This return got removed since we want to keep iterating the rest of the PRs and check them as well

2) When deleting old comments we used to return if the removal failed. Therefore in this case we don't push the new comments. The removal of old comment is not mandatory and should not prevent the addition of newer comments
