### PR TITLE
Only trim spaces of array parameter entries

### DIFF
--- a/utils/params_test.go
+++ b/utils/params_test.go
@@ -162,7 +162,7 @@ func TestExtractAndAssertRepoParams(t *testing.T) {
 		GitEmailAuthorEnv:    "myemail@jfrog.com",
 		MinSeverityEnv:       "high",
 		FixableOnlyEnv:       "true",
-		AllowedLicensesEnv:   "MIT, Apache-2.0, ISC",
+		AllowedLicensesEnv:   "MIT, Apache-2.0, ISC, Public Domain",
 		AvoidExtraMessages:   "true",
 	})
 	defer func() {
@@ -195,7 +195,7 @@ func TestExtractAndAssertRepoParams(t *testing.T) {
 		assert.Equal(t, "myemail@jfrog.com", repo.EmailAuthor)
 		assert.Equal(t, "build 1323", repo.PullRequestCommentTitle)
 		assert.ElementsMatch(t, []string{"watch-2", "watch-1"}, repo.Watches)
-		assert.ElementsMatch(t, []string{"MIT", "ISC", "Apache-2.0"}, repo.AllowedLicenses)
+		assert.ElementsMatch(t, []string{"MIT", "ISC", "Apache-2.0", "Public Domain"}, repo.AllowedLicenses)
 		for _, project := range repo.Projects {
 			testExtractAndAssertProjectParams(t, project)
 		}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/frogbot#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
---

Some packages include a space in the names of their license. In particular this is a problem with “Public Domain” in org.json:json here: https://github.com/stleary/JSON-java/blob/master/pom.xml#L32

I added the function to read the list of allowed licenses from the environment variable that does not remove all spaces but only ones at the beginning and end of each individual entry. This preserves spaces inside the entries. I have updated a unit test to cover this change.

Note: While all unit tests are passing, the GitHub Job “Scan Pull Request Tests” fails in my fork. This, however, appears not to be related to my change, as these were failing before as well. I think this may be caused by a different JFrog server version that reports some vulnerabilities slightly different from what is expected by these tests.

Please let me know if I need to change anything to move this PR forward.