### PR TITLE
downgrading .NET SDK version in a test project from 7.0 to 6.0 

### DIFF
--- a/testdata/projects/dotnet/dotnet.csproj
+++ b/testdata/projects/dotnet/dotnet.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/frogbot#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] Update [documentation](https://github.com/jfrog/documentation) about new features / new supported technologies
---

In order to support new automated tests CI (Jfrog-pipelines) the .NET SDK version in a .NET test project had to be downgraded from v7.0 to v6.0
