### PR TITLE
Fix unmasked clone urls in DEBUG prints

### DIFF
--- a/utils/git.go
+++ b/utils/git.go
@@ -163,8 +163,8 @@ func (gm *GitManager) Clone(destinationPath, branchName string) error {
 	transport.UnsupportedCapabilities = []capability.Capability{
 		capability.ThinPack,
 	}
-	maskedRemoteGitUrl := getMaskedUrlIfNeeded(gm.remoteGitUrl)
-	log.Debug(fmt.Sprintf("Running git clone %s (%s branch)...", maskedRemoteGitUrl, branchName))
+	credentialsFreeRemoteGitUrl := removeCredentialsFromUrlIfNeeded(gm.remoteGitUrl)
+	log.Debug(fmt.Sprintf("Running git clone %s (%s branch)...", credentialsFreeRemoteGitUrl, branchName))
 	cloneOptions := &git.CloneOptions{
 		URL:           gm.remoteGitUrl,
 		Auth:          gm.auth,
@@ -176,10 +176,10 @@ func (gm *GitManager) Clone(destinationPath, branchName string) error {
 	}
 	repo, err := git.PlainClone(destinationPath, false, cloneOptions)
 	if err != nil {
-		return fmt.Errorf("git clone %s from %s failed with error: %s", branchName, maskedRemoteGitUrl, err.Error())
+		return fmt.Errorf("git clone %s from %s failed with error: %s", branchName, credentialsFreeRemoteGitUrl, err.Error())
 	}
 	gm.localGitRepository = repo
-	log.Debug(fmt.Sprintf("Project cloned from %s to %s", maskedRemoteGitUrl, destinationPath))
+	log.Debug(fmt.Sprintf("Project cloned from %s to %s", credentialsFreeRemoteGitUrl, destinationPath))
 	return nil
 }
 
@@ -515,7 +515,9 @@ func parseCustomTemplate(customTemplate string, tech []techutils.Technology) str
 	return normalizeWhitespaces(result) + suffix
 }
 
-func getMaskedUrlIfNeeded(url string) string {
+// Removes credentials from clone URL if needed
+// Example: https://<username>:<token>@<repo url> -> https://<repo url>
+func removeCredentialsFromUrlIfNeeded(url string) string {
 	matchedResult := regexp.MustCompile(clientutils.CredentialsInUrlRegexp).FindString(url)
 	if matchedResult == "" {
 		return url

--- a/utils/git.go
+++ b/utils/git.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/transport/client"
 	"github.com/jfrog/froggit-go/vcsutils"
 	"github.com/jfrog/jfrog-cli-security/utils/techutils"
+	clientutils "github.com/jfrog/jfrog-client-go/utils"
 	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
 
 	"github.com/go-git/go-git/v5"
@@ -162,7 +163,8 @@ func (gm *GitManager) Clone(destinationPath, branchName string) error {
 	transport.UnsupportedCapabilities = []capability.Capability{
 		capability.ThinPack,
 	}
-	log.Debug(fmt.Sprintf("Running git clone %s (%s branch)...", gm.remoteGitUrl, branchName))
+	maskedRemoteGitUrl := getMaskedUrlIfNeeded(gm.remoteGitUrl)
+	log.Debug(fmt.Sprintf("Running git clone %s (%s branch)...", maskedRemoteGitUrl, branchName))
 	cloneOptions := &git.CloneOptions{
 		URL:           gm.remoteGitUrl,
 		Auth:          gm.auth,
@@ -174,10 +176,10 @@ func (gm *GitManager) Clone(destinationPath, branchName string) error {
 	}
 	repo, err := git.PlainClone(destinationPath, false, cloneOptions)
 	if err != nil {
-		return fmt.Errorf("git clone %s from %s failed with error: %s", branchName, gm.remoteGitUrl, err.Error())
+		return fmt.Errorf("git clone %s from %s failed with error: %s", branchName, maskedRemoteGitUrl, err.Error())
 	}
 	gm.localGitRepository = repo
-	log.Debug(fmt.Sprintf("Project cloned from %s to %s", gm.remoteGitUrl, destinationPath))
+	log.Debug(fmt.Sprintf("Project cloned from %s to %s", maskedRemoteGitUrl, destinationPath))
 	return nil
 }
 
@@ -511,4 +513,12 @@ func parseCustomTemplate(customTemplate string, tech []techutils.Technology) str
 		suffix = " - %s Dependencies"
 	}
 	return normalizeWhitespaces(result) + suffix
+}
+
+func getMaskedUrlIfNeeded(url string) string {
+	matchedResult := regexp.MustCompile(clientutils.CredentialsInUrlRegexp).FindString(url)
+	if matchedResult == "" {
+		return url
+	}
+	return clientutils.RemoveCredentials(url, matchedResult)
 }

--- a/utils/git_test.go
+++ b/utils/git_test.go
@@ -389,7 +389,7 @@ func TestGetAggregatedPullRequestTitle(t *testing.T) {
 	}
 }
 
-func TestGetMaskedUrlIfNeeded(t *testing.T) {
+func TestRemoveCredentialsFromUrlIfNeeded(t *testing.T) {
 	testsCases := []struct {
 		url      string
 		expected string
@@ -400,12 +400,14 @@ func TestGetMaskedUrlIfNeeded(t *testing.T) {
 		{url: "http://<user>:<token>@git.jfrog.info/scm/jfrog/some-service.git", expected: "http://git.jfrog.info/scm/jfrog/some-service.git"},
 		{url: "git://example.com/owner/repo.git", expected: "git://example.com/owner/repo.git"},
 		{url: "git://<user>:<token>@git.jfrog.info/scm/jfrog/some-service.git", expected: "git://git.jfrog.info/scm/jfrog/some-service.git"},
+		{url: "git://<user>:<token>@git.jfrog.info/scm/jfrog/some-service.git", expected: "git://git.jfrog.info/scm/jfrog/some-service.git"},
+		{url: "ssh://git@example.com/owner/repo.git", expected: "ssh://git@example.com/owner/repo.git"},
 	}
 
 	for _, testcase := range testsCases {
 		t.Run("case: "+testcase.url, func(t *testing.T) {
-			maskedUrl := getMaskedUrlIfNeeded(testcase.url)
-			assert.Equal(t, testcase.expected, maskedUrl)
+			cleanUrl := removeCredentialsFromUrlIfNeeded(testcase.url)
+			assert.Equal(t, testcase.expected, cleanUrl)
 		})
 	}
 }

--- a/utils/git_test.go
+++ b/utils/git_test.go
@@ -388,3 +388,24 @@ func TestGetAggregatedPullRequestTitle(t *testing.T) {
 		})
 	}
 }
+
+func TestGetMaskedUrlIfNeeded(t *testing.T) {
+	testsCases := []struct {
+		url      string
+		expected string
+	}{
+		{url: "https://example.com/owner/repo.git", expected: "https://example.com/owner/repo.git"},
+		{url: "https://<user>:<token>@git.jfrog.info/scm/jfrog/some-service.git", expected: "https://git.jfrog.info/scm/jfrog/some-service.git"},
+		{url: "http://example.com/owner/repo.git", expected: "http://example.com/owner/repo.git"},
+		{url: "http://<user>:<token>@git.jfrog.info/scm/jfrog/some-service.git", expected: "http://git.jfrog.info/scm/jfrog/some-service.git"},
+		{url: "git://example.com/owner/repo.git", expected: "git://example.com/owner/repo.git"},
+		{url: "git://<user>:<token>@git.jfrog.info/scm/jfrog/some-service.git", expected: "git://git.jfrog.info/scm/jfrog/some-service.git"},
+	}
+
+	for _, testcase := range testsCases {
+		t.Run("case: "+testcase.url, func(t *testing.T) {
+			maskedUrl := getMaskedUrlIfNeeded(testcase.url)
+			assert.Equal(t, testcase.expected, maskedUrl)
+		})
+	}
+}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/frogbot#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
- [x] Update [documentation](https://github.com/jfrog/documentation) about new features / new supported technologies
---

This PR fixes the issue of printing unmasked URLs in Frogbot's cloning process