### PR TITLE
Add option to skip auto fix in Frogbot scan repository

### DIFF
--- a/scanrepository/scanrepository.go
+++ b/scanrepository/scanrepository.go
@@ -176,7 +176,9 @@ func (cfp *ScanRepositoryCmd) scanAndFixProject(repository *utils.Repository) er
 		}
 		vulnerabilitiesByPathMap[fullPathWd] = currPathVulnerabilities
 	}
-	if fixNeeded {
+	if repository.DetectionOnly {
+		log.Info(fmt.Sprintf("This command is running in detection mode only. To enable automatic fixing of issues, set the '%s' environment variable to 'false'.", utils.DetectionOnlyEnv))
+	} else if fixNeeded {
 		return cfp.fixVulnerablePackages(repository, vulnerabilitiesByPathMap)
 	}
 	return nil

--- a/utils/consts.go
+++ b/utils/consts.go
@@ -60,6 +60,7 @@ const (
 	DepsRepoEnv                        = "JF_DEPS_REPO"
 	MinSeverityEnv                     = "JF_MIN_SEVERITY"
 	FixableOnlyEnv                     = "JF_FIXABLE_ONLY"
+	DetectionOnlyEnv                   = "JF_SKIP_FIX_CREATION"
 	AllowedLicensesEnv                 = "JF_ALLOWED_LICENSES"
 	WatchesDelimiter                   = ","
 

--- a/utils/consts.go
+++ b/utils/consts.go
@@ -60,7 +60,7 @@ const (
 	DepsRepoEnv                        = "JF_DEPS_REPO"
 	MinSeverityEnv                     = "JF_MIN_SEVERITY"
 	FixableOnlyEnv                     = "JF_FIXABLE_ONLY"
-	DetectionOnlyEnv                   = "JF_SKIP_FIX_CREATION"
+	DetectionOnlyEnv                   = "JF_SKIP_AUTOFIX"
 	AllowedLicensesEnv                 = "JF_ALLOWED_LICENSES"
 	WatchesDelimiter                   = ","
 

--- a/utils/params.go
+++ b/utils/params.go
@@ -132,7 +132,7 @@ func (p *Project) setDefaultsIfNeeded() error {
 type Scan struct {
 	IncludeAllVulnerabilities       bool      `yaml:"includeAllVulnerabilities,omitempty"`
 	FixableOnly                     bool      `yaml:"fixableOnly,omitempty"`
-	DetectionOnly                   bool      `yaml:"detectOnly,omitempty"`
+	DetectionOnly                   bool      `yaml:"skipAutoFix,omitempty"`
 	FailOnSecurityIssues            *bool     `yaml:"failOnSecurityIssues,omitempty"`
 	AvoidPreviousPrCommentsDeletion bool      `yaml:"avoidPreviousPrCommentsDeletion,omitempty"`
 	MinSeverity                     string    `yaml:"minSeverity,omitempty"`

--- a/utils/params.go
+++ b/utils/params.go
@@ -132,6 +132,7 @@ func (p *Project) setDefaultsIfNeeded() error {
 type Scan struct {
 	IncludeAllVulnerabilities       bool      `yaml:"includeAllVulnerabilities,omitempty"`
 	FixableOnly                     bool      `yaml:"fixableOnly,omitempty"`
+	DetectionOnly                   bool      `yaml:"detectOnly,omitempty"`
 	FailOnSecurityIssues            *bool     `yaml:"failOnSecurityIssues,omitempty"`
 	AvoidPreviousPrCommentsDeletion bool      `yaml:"avoidPreviousPrCommentsDeletion,omitempty"`
 	MinSeverity                     string    `yaml:"minSeverity,omitempty"`
@@ -190,6 +191,11 @@ func (s *Scan) setDefaultsIfNeeded() (err error) {
 	}
 	if !s.FixableOnly {
 		if s.FixableOnly, err = getBoolEnv(FixableOnlyEnv, false); err != nil {
+			return
+		}
+	}
+	if !s.DetectionOnly {
+		if s.DetectionOnly, err = getBoolEnv(DetectionOnlyEnv, false); err != nil {
 			return
 		}
 	}

--- a/utils/params_test.go
+++ b/utils/params_test.go
@@ -166,6 +166,7 @@ func TestExtractAndAssertRepoParams(t *testing.T) {
 		GitEmailAuthorEnv:    "myemail@jfrog.com",
 		MinSeverityEnv:       "high",
 		FixableOnlyEnv:       "true",
+		DetectionOnlyEnv:     "true",
 		AllowedLicensesEnv:   "MIT, Apache-2.0, ISC",
 		AvoidExtraMessages:   "true",
 	})
@@ -195,6 +196,7 @@ func TestExtractAndAssertRepoParams(t *testing.T) {
 		assert.Equal(t, "this is my branch {BRANCH_NAME_HASH}", templates.branchNameTemplate)
 		assert.Equal(t, "High", repo.MinSeverity)
 		assert.True(t, repo.FixableOnly)
+		assert.True(t, repo.DetectionOnly)
 		assert.Equal(t, true, repo.AggregateFixes)
 		assert.Equal(t, "myemail@jfrog.com", repo.EmailAuthor)
 		assert.Equal(t, "build 1323", repo.PullRequestCommentTitle)
@@ -347,6 +349,7 @@ func TestGenerateConfigAggregatorFromEnv(t *testing.T) {
 		FailOnSecurityIssuesEnv:            "false",
 		MinSeverityEnv:                     "medium",
 		FixableOnlyEnv:                     "true",
+		DetectionOnlyEnv:                   "true",
 		AllowedLicensesEnv:                 "MIT, Apache-2.0",
 		AvoidExtraMessages:                 "true",
 		PullRequestCommentTitleEnv:         "build 1323",
@@ -389,6 +392,7 @@ func validateBuildRepoAggregator(t *testing.T, repo *Repository, gitParams *Git,
 	assert.Equal(t, false, *repo.FailOnSecurityIssues)
 	assert.Equal(t, "Medium", repo.MinSeverity)
 	assert.Equal(t, true, repo.FixableOnly)
+	assert.Equal(t, true, repo.DetectionOnly)
 	assert.ElementsMatch(t, []string{"MIT", "Apache-2.0"}, repo.AllowedLicenses)
 	assert.Equal(t, gitParams.RepoOwner, repo.RepoOwner)
 	assert.Equal(t, gitParams.Token, repo.Token)


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/frogbot#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
- [x] Update [documentation](https://github.com/jfrog/documentation) about new features / new supported technologies
---

Enable a new option (`JF_SKIP_AUTOFIX` / `scan.skipAutoFix`) to skip automatic fix at scan repository command.
IF this option is provided, Frogbot will only detect the issues and will not try to fix them