### PR TITLE
Clear new locally created files before pushing a fix

### DIFF
--- a/scanrepository/scanrepository.go
+++ b/scanrepository/scanrepository.go
@@ -401,7 +401,6 @@ func (cfp *ScanRepositoryCmd) openFixingPullRequest(repository *utils.Repository
 	commitMessage := cfp.gitManager.GenerateCommitMessage(vulnDetails.ImpactedDependencyName, vulnDetails.SuggestedFixedVersion)
 	if err = cfp.cleanNewFilesMissingInRemote(); err != nil {
 		log.Warn(fmt.Sprintf("failed fo clean untracked files from '%s' due to the following errors: %s", cfp.baseWd, err.Error()))
-		err = nil
 	}
 	if err = cfp.gitManager.AddAllAndCommit(commitMessage); err != nil {
 		return
@@ -488,7 +487,7 @@ func (cfp *ScanRepositoryCmd) cleanNewFilesMissingInRemote() error {
 			log.Debug(fmt.Sprintf("Untracking file '%s' that was created locally during the scan/fix process", relativeFilePath))
 			fileDeletionErr := os.Remove(filepath.Join(cfp.baseWd, relativeFilePath))
 			if fileDeletionErr != nil {
-				err = errors.Join(err, errors.New(fmt.Sprintf("file '%s': %s\n", relativeFilePath, fileDeletionErr.Error())))
+				err = errors.Join(err, fmt.Errorf("file '%s': %s\n", relativeFilePath, fileDeletionErr.Error()))
 				continue
 			}
 		}

--- a/scanrepository/scanrepository.go
+++ b/scanrepository/scanrepository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/go-git/go-git/v5"
 	biutils "github.com/jfrog/build-info-go/utils"
 	"os"
 	"path/filepath"
@@ -313,7 +314,7 @@ func (cfp *ScanRepositoryCmd) fixMultiplePackages(fullProjectPath string, vulner
 	return
 }
 
-// fixIssuesSinglePR fixes all the vulnerabilities in a single aggregated pull request.
+// Fixes all the vulnerabilities in a single aggregated pull request.
 // If an existing aggregated fix is present, it checks for different scan results.
 // If the scan results are the same, no action is taken.
 // Otherwise, it performs a force push to the same branch and reopens the pull request if it was closed.
@@ -398,6 +399,9 @@ func (cfp *ScanRepositoryCmd) openFixingPullRequest(repository *utils.Repository
 		return &utils.ErrNothingToCommit{PackageName: vulnDetails.ImpactedDependencyName}
 	}
 	commitMessage := cfp.gitManager.GenerateCommitMessage(vulnDetails.ImpactedDependencyName, vulnDetails.SuggestedFixedVersion)
+	if err = cfp.cleanNewFilesMissingInRemote(); err != nil {
+		return
+	}
 	if err = cfp.gitManager.AddAllAndCommit(commitMessage); err != nil {
 		return
 	}
@@ -443,10 +447,13 @@ func (cfp *ScanRepositoryCmd) createOrUpdatePullRequest(repository *utils.Reposi
 	return pullRequestInfo, utils.DeletePullRequestComments(repository, cfp.scanDetails.Client(), int(pullRequestInfo.ID))
 }
 
-// openAggregatedPullRequest handles the opening or updating of a pull request when the aggregate mode is active.
+// Handles the opening or updating of a pull request when the aggregate mode is active.
 // If a pull request is already open, Frogbot will update the branch and the pull request body.
 func (cfp *ScanRepositoryCmd) openAggregatedPullRequest(repository *utils.Repository, fixBranchName string, pullRequestInfo *vcsclient.PullRequestInfo, vulnerabilities []*utils.VulnerabilityDetails) (err error) {
 	commitMessage := cfp.gitManager.GenerateAggregatedCommitMessage(cfp.projectTech)
+	if err = cfp.cleanNewFilesMissingInRemote(); err != nil {
+		return
+	}
 	if err = cfp.gitManager.AddAllAndCommit(commitMessage); err != nil {
 		return
 	}
@@ -454,6 +461,36 @@ func (cfp *ScanRepositoryCmd) openAggregatedPullRequest(repository *utils.Reposi
 		return
 	}
 	return cfp.handleFixPullRequestContent(repository, fixBranchName, pullRequestInfo, vulnerabilities...)
+}
+
+func (cfp *ScanRepositoryCmd) cleanNewFilesMissingInRemote() error {
+	// Open the local repository and get its Git status
+	localRepo, err := git.PlainOpen(cfp.baseWd)
+	if err != nil {
+		return err
+	}
+
+	worktree, err := localRepo.Worktree()
+	if err != nil {
+		return err
+	}
+
+	gitStatus, err := worktree.Status()
+	if err != nil {
+		return err
+	}
+
+	for relativeFilePath, status := range gitStatus {
+		if status.Worktree == git.Untracked {
+			log.Debug(fmt.Sprintf("Deleting file '%s' that was created locally during the scan/fix process", relativeFilePath))
+			fileDeletionErr := os.Remove(filepath.Join(cfp.baseWd, relativeFilePath))
+			if fileDeletionErr != nil {
+				log.Debug(fmt.Sprintf("Failed to delete file '%s' with error: %w:", relativeFilePath, fileDeletionErr))
+				continue
+			}
+		}
+	}
+	return nil
 }
 
 func (cfp *ScanRepositoryCmd) preparePullRequestDetails(vulnerabilitiesDetails ...*utils.VulnerabilityDetails) (prTitle, prBody string, otherComments []string, err error) {

--- a/scanrepository/scanrepository.go
+++ b/scanrepository/scanrepository.go
@@ -485,7 +485,7 @@ func (cfp *ScanRepositoryCmd) cleanNewFilesMissingInRemote() error {
 			log.Debug(fmt.Sprintf("Deleting file '%s' that was created locally during the scan/fix process", relativeFilePath))
 			fileDeletionErr := os.Remove(filepath.Join(cfp.baseWd, relativeFilePath))
 			if fileDeletionErr != nil {
-				log.Debug(fmt.Sprintf("Failed to delete file '%s' with error: %w:", relativeFilePath, fileDeletionErr))
+				log.Debug(fmt.Sprintf("Failed to delete file '%s' with error: %s:", relativeFilePath, fileDeletionErr.Error()))
 				continue
 			}
 		}

--- a/scanrepository/scanrepository_test.go
+++ b/scanrepository/scanrepository_test.go
@@ -688,12 +688,12 @@ func TestCleanNewFilesMissingInRemote(t *testing.T) {
 		createFileBeforeInit bool
 	}{
 		{
-			name:                 "new file should remain",
+			name:                 "new_file_should_remain",
 			relativeTestDirPath:  filepath.Join(rootTestDir, "cmd", "aggregate"),
 			createFileBeforeInit: true,
 		},
 		{
-			name:                 "new file should be deleted",
+			name:                 "new_file_should_be_deleted",
 			relativeTestDirPath:  filepath.Join(rootTestDir, "cmd", "aggregate"),
 			createFileBeforeInit: false,
 		},
@@ -712,8 +712,9 @@ func TestCleanNewFilesMissingInRemote(t *testing.T) {
 
 			var file *os.File
 			var filePath string
+			tempFileName := test.name + ".txt"
 			if test.createFileBeforeInit {
-				filePath, file = utils.CreateFileInPathAndAssert(t, testDir, "myFile.txt")
+				filePath, file = utils.CreateFileInPathAndAssert(t, testDir, tempFileName)
 				defer func() {
 					assert.NoError(t, file.Close())
 				}()
@@ -722,7 +723,7 @@ func TestCleanNewFilesMissingInRemote(t *testing.T) {
 			utils.CreateDotGitWithCommit(t, testDir, "1234", "")
 
 			if !test.createFileBeforeInit {
-				filePath, file = utils.CreateFileInPathAndAssert(t, testDir, "myFile.txt")
+				filePath, file = utils.CreateFileInPathAndAssert(t, testDir, tempFileName)
 				defer func() {
 					assert.NoError(t, file.Close())
 				}()

--- a/scanrepository/scanrepository_test.go
+++ b/scanrepository/scanrepository_test.go
@@ -711,10 +711,10 @@ func TestCleanNewFilesMissingInRemote(t *testing.T) {
 			defer cleanup()
 
 			var file *os.File
-			var filePath string
-			tempFileName := test.name + ".txt"
 			if test.createFileBeforeInit {
-				filePath, file = utils.CreateFileInPathAndAssert(t, testDir, tempFileName)
+				var fileError error
+				file, fileError = os.CreateTemp(testDir, test.name)
+				assert.NoError(t, fileError)
 				defer func() {
 					assert.NoError(t, file.Close())
 				}()
@@ -723,7 +723,9 @@ func TestCleanNewFilesMissingInRemote(t *testing.T) {
 			utils.CreateDotGitWithCommit(t, testDir, "1234", "")
 
 			if !test.createFileBeforeInit {
-				filePath, file = utils.CreateFileInPathAndAssert(t, testDir, tempFileName)
+				var fileError error
+				file, fileError = os.CreateTemp(testDir, test.name)
+				assert.NoError(t, fileError)
 				defer func() {
 					assert.NoError(t, file.Close())
 				}()
@@ -736,7 +738,7 @@ func TestCleanNewFilesMissingInRemote(t *testing.T) {
 			scanRepoCmd := ScanRepositoryCmd{baseWd: testDir}
 			assert.NoError(t, scanRepoCmd.cleanNewFilesMissingInRemote())
 
-			exists, err := fileutils.IsFileExists(filePath, false)
+			exists, err := fileutils.IsFileExists(file.Name(), false)
 			assert.NoError(t, err)
 			if test.createFileBeforeInit {
 				assert.True(t, exists)

--- a/scanrepository/scanrepository_test.go
+++ b/scanrepository/scanrepository_test.go
@@ -3,7 +3,6 @@ package scanrepository
 import (
 	"errors"
 	"fmt"
-	"github.com/go-git/go-git/v5"
 	"github.com/google/go-github/v45/github"
 	biutils "github.com/jfrog/build-info-go/utils"
 	"github.com/jfrog/frogbot/v2/utils"
@@ -720,14 +719,7 @@ func TestCleanNewFilesMissingInRemote(t *testing.T) {
 				}()
 			}
 
-			// Creating .git and commiting existing changes to simulate a clean worktree
-			dotGit, err := git.PlainInit(testDir, false)
-			assert.NoError(t, err)
-			worktree, err := dotGit.Worktree()
-			assert.NoError(t, err)
-			assert.NoError(t, worktree.AddWithOptions(&git.AddOptions{All: true}))
-			_, err = worktree.Commit("first commit", &git.CommitOptions{})
-			assert.NoError(t, err)
+			utils.CreateDotGitWithCommit(t, testDir, "1234", "")
 
 			if !test.createFileBeforeInit {
 				filePath, file = utils.CreateFileInPathAndAssert(t, testDir, "myFile.txt")
@@ -737,7 +729,7 @@ func TestCleanNewFilesMissingInRemote(t *testing.T) {
 			}
 
 			// Making a change in the file so it will be modified in the working tree
-			_, err = file.WriteString("My initial string")
+			_, err := file.WriteString("My initial string")
 			assert.NoError(t, err)
 
 			scanRepoCmd := ScanRepositoryCmd{baseWd: testDir}

--- a/scanrepository/scanrepository_test.go
+++ b/scanrepository/scanrepository_test.go
@@ -715,9 +715,12 @@ func TestCleanNewFilesMissingInRemote(t *testing.T) {
 				var fileError error
 				file, fileError = os.CreateTemp(testDir, test.name)
 				assert.NoError(t, fileError)
-				defer func() {
-					assert.NoError(t, file.Close())
-				}()
+				/*
+					defer func() {
+						assert.NoError(t, file.Close())
+					}()
+
+				*/
 			}
 
 			utils.CreateDotGitWithCommit(t, testDir, "1234", "")
@@ -726,14 +729,18 @@ func TestCleanNewFilesMissingInRemote(t *testing.T) {
 				var fileError error
 				file, fileError = os.CreateTemp(testDir, test.name)
 				assert.NoError(t, fileError)
-				defer func() {
-					assert.NoError(t, file.Close())
-				}()
+				/*
+					defer func() {
+						assert.NoError(t, file.Close())
+					}()
+
+				*/
 			}
 
 			// Making a change in the file so it will be modified in the working tree
 			_, err := file.WriteString("My initial string")
 			assert.NoError(t, err)
+			assert.NoError(t, file.Close())
 
 			scanRepoCmd := ScanRepositoryCmd{baseWd: testDir}
 			assert.NoError(t, scanRepoCmd.cleanNewFilesMissingInRemote())

--- a/scanrepository/scanrepository_test.go
+++ b/scanrepository/scanrepository_test.go
@@ -715,12 +715,6 @@ func TestCleanNewFilesMissingInRemote(t *testing.T) {
 				var fileError error
 				file, fileError = os.CreateTemp(testDir, test.name)
 				assert.NoError(t, fileError)
-				/*
-					defer func() {
-						assert.NoError(t, file.Close())
-					}()
-
-				*/
 			}
 
 			utils.CreateDotGitWithCommit(t, testDir, "1234", "")
@@ -729,12 +723,6 @@ func TestCleanNewFilesMissingInRemote(t *testing.T) {
 				var fileError error
 				file, fileError = os.CreateTemp(testDir, test.name)
 				assert.NoError(t, fileError)
-				/*
-					defer func() {
-						assert.NoError(t, file.Close())
-					}()
-
-				*/
 			}
 
 			// Making a change in the file so it will be modified in the working tree

--- a/utils/git.go
+++ b/utils/git.go
@@ -466,6 +466,18 @@ func (gm *GitManager) dryRunClone(destination string) error {
 	return nil
 }
 
+func (gm *GitManager) GetRemoteGitUrl() string {
+	return gm.remoteGitUrl
+}
+
+func (gm *GitManager) GetAuth() *githttp.BasicAuth {
+	return gm.auth
+}
+
+func (gm *GitManager) GetRemoteName() string {
+	return gm.remoteName
+}
+
 func toBasicAuth(username, token string) *githttp.BasicAuth {
 	// The username can be anything except for an empty string
 	if username == "" {

--- a/utils/testsutils.go
+++ b/utils/testsutils.go
@@ -216,3 +216,10 @@ func CreateXscMockServerForConfigProfile(t *testing.T) (mockServer *httptest.Ser
 	}
 	return
 }
+
+func CreateFileInPathAndAssert(t *testing.T, path string, fileName string) (string, *os.File) {
+	filePath := filepath.Join(path, fileName)
+	file, err := os.Create(filePath)
+	assert.NoError(t, err)
+	return filePath, file
+}

--- a/utils/testsutils.go
+++ b/utils/testsutils.go
@@ -216,10 +216,3 @@ func CreateXscMockServerForConfigProfile(t *testing.T) (mockServer *httptest.Ser
 	}
 	return
 }
-
-func CreateFileInPathAndAssert(t *testing.T, path string, fileName string) (string, *os.File) {
-	filePath := filepath.Join(path, fileName)
-	file, err := os.Create(filePath)
-	assert.NoError(t, err)
-	return filePath, file
-}


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/frogbot#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
- [ ] Update [documentation](https://github.com/jfrog/documentation) about new features / new supported technologies
---

This PR improves Frogbot's ability to detect new locally created files, and remove them before pushing the fixes PRs.
This improvement allows Frogbot to push cleaner PRs ,with changes ONLY in the already existing files and not pushing newly created files (like new lock files, node_modules etc...)
