### PR TITLE
Add option to disable Jas scans

### DIFF
--- a/scanpullrequest/scanpullrequest.go
+++ b/scanpullrequest/scanpullrequest.go
@@ -136,7 +136,8 @@ func auditPullRequest(repoConfig *utils.Repository, client vcsclient.VcsClient, 
 		SetFixableOnly(repoConfig.FixableOnly).
 		SetFailOnInstallationErrors(*repoConfig.FailOnSecurityIssues).
 		SetConfigProfile(repoConfig.ConfigProfile).
-		SetSkipAutoInstall(repoConfig.SkipAutoInstall)
+		SetSkipAutoInstall(repoConfig.SkipAutoInstall).
+		SetDisableJas(repoConfig.DisableJas)
 	if scanDetails, err = scanDetails.SetMinSeverity(repoConfig.MinSeverity); err != nil {
 		return
 	}

--- a/scanrepository/scanrepository.go
+++ b/scanrepository/scanrepository.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/go-git/go-git/v5"
-	biutils "github.com/jfrog/build-info-go/utils"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/go-git/go-git/v5"
+	biutils "github.com/jfrog/build-info-go/utils"
 
 	"github.com/jfrog/frogbot/v2/packagehandlers"
 	"github.com/jfrog/frogbot/v2/utils"
@@ -123,8 +124,7 @@ func (cfp *ScanRepositoryCmd) setCommandPrerequisites(repository *utils.Reposito
 		SetFailOnInstallationErrors(*repository.FailOnSecurityIssues).
 		SetFixableOnly(repository.FixableOnly).
 		SetSkipAutoInstall(repository.SkipAutoInstall).
-		SetFixableOnly(repository.FixableOnly).
-		SetAllowPartialResults(repository.AllowPartialResults)
+		SetAllowPartialResults(repository.AllowPartialResults).SetDisableJas(repository.DisableJas)
 	if cfp.scanDetails, err = cfp.scanDetails.SetMinSeverity(repository.MinSeverity); err != nil {
 		return
 	}

--- a/scanrepository/scanrepository.go
+++ b/scanrepository/scanrepository.go
@@ -124,7 +124,8 @@ func (cfp *ScanRepositoryCmd) setCommandPrerequisites(repository *utils.Reposito
 		SetFailOnInstallationErrors(*repository.FailOnSecurityIssues).
 		SetFixableOnly(repository.FixableOnly).
 		SetSkipAutoInstall(repository.SkipAutoInstall).
-		SetAllowPartialResults(repository.AllowPartialResults).SetDisableJas(repository.DisableJas)
+		SetAllowPartialResults(repository.AllowPartialResults).
+		SetDisableJas(repository.DisableJas)
 	if cfp.scanDetails, err = cfp.scanDetails.SetMinSeverity(repository.MinSeverity); err != nil {
 		return
 	}

--- a/utils/consts.go
+++ b/utils/consts.go
@@ -61,7 +61,7 @@ const (
 	DepsRepoEnv                        = "JF_DEPS_REPO"
 	MinSeverityEnv                     = "JF_MIN_SEVERITY"
 	FixableOnlyEnv                     = "JF_FIXABLE_ONLY"
-	DisableJasEnv                      = "JF_DISABLE_ADVANCE_SECURITY"
+	DisableJasEnv                      = "JF_DISABLE_ADVANCED_SECURITY"
 	DetectionOnlyEnv                   = "JF_SKIP_AUTOFIX"
 	AllowedLicensesEnv                 = "JF_ALLOWED_LICENSES"
 	SkipAutoInstallEnv                 = "JF_SKIP_AUTO_INSTALL"

--- a/utils/consts.go
+++ b/utils/consts.go
@@ -61,6 +61,7 @@ const (
 	DepsRepoEnv                        = "JF_DEPS_REPO"
 	MinSeverityEnv                     = "JF_MIN_SEVERITY"
 	FixableOnlyEnv                     = "JF_FIXABLE_ONLY"
+	DisableJasEnv                      = "JF_DISABLE_ADVANCE_SECURITY"
 	DetectionOnlyEnv                   = "JF_SKIP_AUTOFIX"
 	AllowedLicensesEnv                 = "JF_ALLOWED_LICENSES"
 	SkipAutoInstallEnv                 = "JF_SKIP_AUTO_INSTALL"

--- a/utils/params.go
+++ b/utils/params.go
@@ -4,16 +4,17 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/jfrog/jfrog-cli-security/utils/techutils"
-	"github.com/jfrog/jfrog-cli-security/utils/xsc"
-	"github.com/jfrog/jfrog-client-go/xsc/services"
-	"golang.org/x/exp/slices"
 	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	"github.com/jfrog/jfrog-cli-security/utils/techutils"
+	"github.com/jfrog/jfrog-cli-security/utils/xsc"
+	"github.com/jfrog/jfrog-client-go/xsc/services"
+	"golang.org/x/exp/slices"
 
 	"github.com/jfrog/frogbot/v2/utils/outputwriter"
 	securityutils "github.com/jfrog/jfrog-cli-security/utils"
@@ -153,6 +154,7 @@ type Scan struct {
 	FailOnSecurityIssues            *bool     `yaml:"failOnSecurityIssues,omitempty"`
 	AvoidPreviousPrCommentsDeletion bool      `yaml:"avoidPreviousPrCommentsDeletion,omitempty"`
 	MinSeverity                     string    `yaml:"minSeverity,omitempty"`
+	DisableJas                      bool      `yaml:"disableJas,omitempty"`
 	AllowedLicenses                 []string  `yaml:"allowedLicenses,omitempty"`
 	Projects                        []Project `yaml:"projects,omitempty"`
 	EmailDetails                    `yaml:",inline"`
@@ -210,6 +212,11 @@ func (s *Scan) setDefaultsIfNeeded() (err error) {
 	}
 	if !s.FixableOnly {
 		if s.FixableOnly, err = getBoolEnv(FixableOnlyEnv, false); err != nil {
+			return
+		}
+	}
+	if !s.DisableJas {
+		if s.DisableJas, err = getBoolEnv(DisableJasEnv, false); err != nil {
 			return
 		}
 	}

--- a/utils/params_test.go
+++ b/utils/params_test.go
@@ -4,11 +4,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/jfrog/jfrog-client-go/utils/tests"
-	"github.com/jfrog/jfrog-client-go/xsc/services"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/jfrog/jfrog-client-go/utils/tests"
+	"github.com/jfrog/jfrog-client-go/xsc/services"
 
 	"github.com/jfrog/froggit-go/vcsclient"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
@@ -166,6 +167,7 @@ func TestExtractAndAssertRepoParams(t *testing.T) {
 		GitEmailAuthorEnv:    "myemail@jfrog.com",
 		MinSeverityEnv:       "high",
 		FixableOnlyEnv:       "true",
+		DisableJasEnv:        "true",
 		DetectionOnlyEnv:     "true",
 		AllowedLicensesEnv:   "MIT, Apache-2.0, ISC",
 		AvoidExtraMessages:   "true",
@@ -196,6 +198,7 @@ func TestExtractAndAssertRepoParams(t *testing.T) {
 		assert.Equal(t, "this is my branch {BRANCH_NAME_HASH}", templates.branchNameTemplate)
 		assert.Equal(t, "High", repo.MinSeverity)
 		assert.True(t, repo.FixableOnly)
+		assert.True(t, repo.DisableJas)
 		assert.True(t, repo.DetectionOnly)
 		assert.Equal(t, true, repo.AggregateFixes)
 		assert.Equal(t, "myemail@jfrog.com", repo.EmailAuthor)
@@ -349,6 +352,7 @@ func TestGenerateConfigAggregatorFromEnv(t *testing.T) {
 		FailOnSecurityIssuesEnv:            "false",
 		MinSeverityEnv:                     "medium",
 		FixableOnlyEnv:                     "true",
+		DisableJasEnv:                      "true",
 		DetectionOnlyEnv:                   "true",
 		AllowedLicensesEnv:                 "MIT, Apache-2.0",
 		AvoidExtraMessages:                 "true",
@@ -392,6 +396,7 @@ func validateBuildRepoAggregator(t *testing.T, repo *Repository, gitParams *Git,
 	assert.Equal(t, false, *repo.FailOnSecurityIssues)
 	assert.Equal(t, "Medium", repo.MinSeverity)
 	assert.Equal(t, true, repo.FixableOnly)
+	assert.Equal(t, true, repo.DisableJas)
 	assert.Equal(t, true, repo.DetectionOnly)
 	assert.ElementsMatch(t, []string{"MIT", "Apache-2.0"}, repo.AllowedLicenses)
 	assert.Equal(t, gitParams.RepoOwner, repo.RepoOwner)

--- a/utils/scandetails.go
+++ b/utils/scandetails.go
@@ -188,7 +188,10 @@ func (sc *ScanDetails) RunInstallAndAudit(workDirs ...string) (auditResults *res
 		SetInstallCommandArgs(sc.InstallCommandArgs).SetUseJas(true).
 		SetTechnologies(sc.GetTechFromInstallCmdIfExists()).
 		SetSkipAutoInstall(sc.skipAutoInstall).
-		SetAllowPartialResults(sc.allowPartialResults)
+		SetAllowPartialResults(sc.allowPartialResults).
+		SetExclusions(sc.PathExclusions).
+		SetIsRecursiveScan(sc.IsRecursiveScan).
+		SetUseJas(!sc.DisableJas())
 
 	auditParams := audit.NewAuditParams().
 		SetWorkingDirs(workDirs).
@@ -197,7 +200,6 @@ func (sc *ScanDetails) RunInstallAndAudit(workDirs ...string) (auditResults *res
 		SetGraphBasicParams(auditBasicParams).
 		SetCommonGraphScanParams(sc.CreateCommonGraphScanParams()).
 		SetConfigProfile(sc.configProfile)
-	auditParams.SetExclusions(sc.PathExclusions).SetIsRecursiveScan(sc.IsRecursiveScan).SetUseJas(!sc.DisableJas())
 
 	auditResults, err = audit.RunAudit(auditParams)
 

--- a/utils/scandetails.go
+++ b/utils/scandetails.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	clientservices "github.com/jfrog/jfrog-client-go/xsc/services"
 	"os"
 	"path/filepath"
+
+	clientservices "github.com/jfrog/jfrog-client-go/xsc/services"
 
 	"github.com/jfrog/froggit-go/vcsclient"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
@@ -28,6 +29,7 @@ type ScanDetails struct {
 	client                   vcsclient.VcsClient
 	failOnInstallationErrors bool
 	fixableOnly              bool
+	disableJas               bool
 	skipAutoInstall          bool
 	minSeverityFilter        severityutils.Severity
 	baseBranch               string
@@ -37,6 +39,11 @@ type ScanDetails struct {
 
 func NewScanDetails(client vcsclient.VcsClient, server *config.ServerDetails, git *Git) *ScanDetails {
 	return &ScanDetails{client: client, ServerDetails: server, Git: git}
+}
+
+func (sc *ScanDetails) SetDisableJas(disable bool) *ScanDetails {
+	sc.disableJas = disable
+	return sc
 }
 
 func (sc *ScanDetails) SetFailOnInstallationErrors(toFail bool) *ScanDetails {
@@ -105,6 +112,10 @@ func (sc *ScanDetails) FailOnInstallationErrors() bool {
 
 func (sc *ScanDetails) FixableOnly() bool {
 	return sc.fixableOnly
+}
+
+func (sc *ScanDetails) DisableJas() bool {
+	return sc.disableJas
 }
 
 func (sc *ScanDetails) MinSeverityFilter() severityutils.Severity {
@@ -186,7 +197,7 @@ func (sc *ScanDetails) RunInstallAndAudit(workDirs ...string) (auditResults *res
 		SetGraphBasicParams(auditBasicParams).
 		SetCommonGraphScanParams(sc.CreateCommonGraphScanParams()).
 		SetConfigProfile(sc.configProfile)
-	auditParams.SetExclusions(sc.PathExclusions).SetIsRecursiveScan(sc.IsRecursiveScan)
+	auditParams.SetExclusions(sc.PathExclusions).SetIsRecursiveScan(sc.IsRecursiveScan).SetUseJas(!sc.DisableJas())
 
 	auditResults, err = audit.RunAudit(auditParams)
 

--- a/utils/scandetails.go
+++ b/utils/scandetails.go
@@ -185,7 +185,7 @@ func (sc *ScanDetails) RunInstallAndAudit(workDirs ...string) (auditResults *res
 		SetIgnoreConfigFile(true).
 		SetServerDetails(sc.ServerDetails).
 		SetInstallCommandName(sc.InstallCommandName).
-		SetInstallCommandArgs(sc.InstallCommandArgs).SetUseJas(true).
+		SetInstallCommandArgs(sc.InstallCommandArgs).
 		SetTechnologies(sc.GetTechFromInstallCmdIfExists()).
 		SetSkipAutoInstall(sc.skipAutoInstall).
 		SetAllowPartialResults(sc.allowPartialResults).


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/frogbot#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
- [x] Update [documentation](https://github.com/jfrog/documentation) about new features / new supported technologies
---

Add option in config (`disableJas`)/ env var (`JF_DISABLE_ADVANCED_SECURITY`) to disable JAS scans