### PR TITLE
Add option to control the Pnpm dependencies tree depth

### DIFF
--- a/utils/consts.go
+++ b/utils/consts.go
@@ -53,6 +53,7 @@ const (
 
 	// Repository environment variables - Ignored if the frogbot-config.yml file is used
 	InstallCommandEnv                  = "JF_INSTALL_DEPS_CMD"
+	MaxPnpmTreeDepthEnv                = "JF_PNPM_MAX_TREE_DEPTH"
 	RequirementsFileEnv                = "JF_REQUIREMENTS_FILE"
 	WorkingDirectoryEnv                = "JF_WORKING_DIR"
 	PathExclusionsEnv                  = "JF_PATH_EXCLUSIONS"

--- a/utils/params.go
+++ b/utils/params.go
@@ -89,6 +89,7 @@ type Project struct {
 	WorkingDirs         []string `yaml:"workingDirs,omitempty"`
 	PathExclusions      []string `yaml:"pathExclusions,omitempty"`
 	UseWrapper          *bool    `yaml:"useWrapper,omitempty"`
+	MaxPnpmTreeDepth    string   `yaml:"maxPnpmTreeDepth,omitempty"`
 	DepsRepo            string   `yaml:"repository,omitempty"`
 	InstallCommandName  string
 	InstallCommandArgs  []string
@@ -131,6 +132,10 @@ func (p *Project) setDefaultsIfNeeded() error {
 	if p.DepsRepo == "" {
 		p.DepsRepo = getTrimmedEnv(DepsRepoEnv)
 	}
+	if p.MaxPnpmTreeDepth == "" {
+		p.MaxPnpmTreeDepth = getTrimmedEnv(MaxPnpmTreeDepthEnv)
+	}
+
 	return nil
 }
 

--- a/utils/scandetails.go
+++ b/utils/scandetails.go
@@ -180,6 +180,7 @@ func (sc *ScanDetails) RunInstallAndAudit(workDirs ...string) (auditResults *res
 		SetXscVersion(sc.XscVersion).
 		SetPipRequirementsFile(sc.PipRequirementsFile).
 		SetUseWrapper(*sc.UseWrapper).
+		SetMaxTreeDepth(sc.MaxPnpmTreeDepth).
 		SetDepsRepo(sc.DepsRepo).
 		SetIgnoreConfigFile(true).
 		SetServerDetails(sc.ServerDetails).


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/frogbot#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
- [x] Update [documentation](https://github.com/jfrog/documentation) about new features / new supported technologies
---

You can now pass `JF_PNPM_MAX_TREE_DEPTH` to control the max depth of the Pnpm dependency tree generated.