### PR TITLE
Don't access ScanStatus on nil

### DIFF
--- a/scanpullrequest/scanpullrequest.go
+++ b/scanpullrequest/scanpullrequest.go
@@ -163,8 +163,10 @@ func auditPullRequest(repoConfig *utils.Repository, client vcsclient.VcsClient) 
 		scanDetails.SetProject(&repoConfig.Projects[i])
 		var projectIssues *issues.ScansIssuesCollection
 		if projectIssues, err = auditPullRequestInProject(repoConfig, scanDetails); err != nil {
-			// Make sure status on scans are passed to show in the summary
-			issuesCollection.AppendStatus(projectIssues.ScanStatus)
+			if projectIssues != nil {
+				// Make sure status on scans are passed to show in the summary
+				issuesCollection.AppendStatus(projectIssues.ScanStatus)
+			}
 			return
 		}
 		issuesCollection.Append(projectIssues)


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/frogbot#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] Update [documentation](https://github.com/jfrog/documentation) about new features / new supported technologies
---

When scan fails or issue occur, `projectIssues *issues.ScansIssuesCollection` can sometime be `nil` that caused `PANIC`

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xf77e89]
goroutine 1 [running]:
github.com/jfrog/frogbot/v2/scanpullrequest.auditPullRequest(0xc0003db208, {0x1580e40, 0xc0003a8ba0})
	/var/opt/jfrog/pipelines/data/release_frogbot/runs/4285355/steps/Release/31033311/dependencyState/resources/frogbotGit/scanpullrequest/scanpullrequest.go:167 +0x4e9
github.com/jfrog/frogbot/v2/scanpullrequest.scanPullRequest(0xc0003db208, {0x1580e40, 0xc0003a8ba0})
	/var/opt/jfrog/pipelines/data/release_frogbot/runs/4285355/steps/Release/31033311/dependencyState/resources/frogbotGit/scanpullrequest/scanpullrequest.go:96 +0x330
github.com/jfrog/frogbot/v2/scanpullrequest.(*ScanPullRequestCmd).Run(0xc00003bef0?, {0xc0003db208, 0x1, 0x1}, {0x1580e40, 0xc0003a8ba0}, 0xc000524c60)
	/var/opt/jfrog/pipelines/data/release_frogbot/runs/4285355/steps/Release/31033311/dependencyState/resources/frogbotGit/scanpullrequest/scanpullrequest.go:48 +0x2d9
main.Exec({0x1568d60, 0x1f72c60}, {0x138a743, 0x11})
	/var/opt/jfrog/pipelines/data/release_frogbot/runs/4285355/steps/Release/31033311/dependencyState/resources/frogbotGit/commands.go:103 +0x46d
main.GetCommands.func1(0xc000343b80?)
	/var/opt/jfrog/pipelines/data/release_frogbot/runs/4285355/steps/Release/31033311/dependencyState/resources/frogbotGit/commands.go:34 +0x2c
github.com/urfave/cli/v2.(*Command).Run(0xc000392160, 0xc000343b80, {0xc00032b6e0, 0x1, 0x1})
	/home/frogger/go/pkg/mod/github.com/urfave/cli/v2@v2.27.4/command.go:276 +0x7e2
github.com/urfave/cli/v2.(*Command).Run(0xc000392840, 0xc000343a40, {0xc0000340c0, 0x2, 0x2})
	/home/frogger/go/pkg/mod/github.com/urfave/cli/v2@v2.27.4/command.go:269 +0xa65
github.com/urfave/cli/v2.(*App).RunContext(0xc0001e2400, {0x1571980, 0x1f72c60}, {0xc0000340c0, 0x2, 0x2})
	/home/frogger/go/pkg/mod/github.com/urfave/cli/v2@v2.27.4/app.go:333 +0x5a5
github.com/urfave/cli/v2.(*App).Run(...)
	/home/frogger/go/pkg/mod/github.com/urfave/cli/v2@v2.27.4/app.go:307
main.ExecMain()
	/var/opt/jfrog/pipelines/data/release_frogbot/runs/4285355/steps/Release/31033311/dependencyState/resources/frogbotGit/main.go:25 +0x13b
main.main()
	/var/opt/jfrog/pipelines/data/release_frogbot/runs/4285355/steps/Release/31033311/dependencyState/resources/frogbotGit/main.go:14 +0x18
```