### PR TITLE
Fix OIDC broken test

### DIFF
--- a/.github/workflows/oidc-test.yml
+++ b/.github/workflows/oidc-test.yml
@@ -39,6 +39,7 @@ jobs:
           "name": "${{ env.OIDC_PROVIDER_NAME }}",
           "issuer_url": "https://token.actions.githubusercontent.com",
           "provider_type": "GitHub",
+          "enable_permissive_configuration": "true"
           "description": "This is a test configuration created for OIDC-Access integration test" }'
 
       - name: Create OIDC integration Identity Mapping

--- a/.github/workflows/oidc-test.yml
+++ b/.github/workflows/oidc-test.yml
@@ -39,7 +39,7 @@ jobs:
           "name": "${{ env.OIDC_PROVIDER_NAME }}",
           "issuer_url": "https://token.actions.githubusercontent.com",
           "provider_type": "GitHub",
-          "enable_permissive_configuration": "true"
+          "enable_permissive_configuration": "true",
           "description": "This is a test configuration created for OIDC-Access integration test" }'
 
       - name: Create OIDC integration Identity Mapping


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/frogbot#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
- [x] Update [documentation](https://github.com/jfrog/documentation) about new features / new supported technologies
---
Due to security enhancement to the OIDC mechanism, identity mappings require more strict fields that will limit the oidc mechanism to a certain flow/owner/repository etc..
Since we want the tests to work in jfrog/frogbot as well as personal forks (in order to reflect changes before merges) we cannot add those kind of fields. Therefore we added a field that allows to use the "lighter" kind of identity mappings like we had before the change. Since this affects only the OIDC test we have no security risk.

We cannot see any CI changes before we merge it, therefore the tests are still seems to be failing here, but in a fork we can see the issue is fixed:

<img width="437" alt="Screenshot 2025-04-02 at 13 45 35" src="https://github.com/user-attachments/assets/cbbb3c90-238a-4c3c-b995-fdd4fd1958a5" />
