### PR TITLE
Handle 406 status code during frogbot-config.yml download

### DIFF
--- a/utils/params.go
+++ b/utils/params.go
@@ -835,6 +835,10 @@ func readConfigFromTarget(client vcsclient.VcsClient, gitParamsFromEnv *Git) (co
 		// If .frogbot/frogbot-config.yml isn't found, return an ErrMissingConfig
 		configContent = nil
 		err = &ErrMissingConfig{errFrogbotConfigNotFound.Error()}
+	case http.StatusNotAcceptable:
+		log.Debug(fmt.Sprintf("The %s file couldn't be retrieved due to content negotiation issues (HTTP 406) in <%s/%s>. Falling back to environment variable configuration.", gitFrogbotConfigPath, repoOwner, repoName))
+		configContent = nil
+		err = nil
 	case http.StatusUnauthorized:
 		log.Warn("Your credentials seem to be invalid. If you are using an on-premises Git provider, please set the API endpoint of your Git provider using the 'JF_GIT_API_ENDPOINT' environment variable (example: 'https://gitlab.example.com'). Additionally, make sure that the provided credentials have the required Git permissions.")
 	}


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/frogbot#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] Update [documentation](https://github.com/jfrog/documentation) about new features / new supported technologies
---

This PR resolves the issue of incorrectly handle of 406 status code that can be returned from frogbot-config.yml download

