### PR TITLE
Fix OIDC test

### DIFF
--- a/.github/workflows/oidc-test.yml
+++ b/.github/workflows/oidc-test.yml
@@ -80,6 +80,7 @@ jobs:
           JF_URL: ${{ secrets.PLATFORM_URL }}
           JF_GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JF_GIT_BASE_BRANCH: ${{ matrix.branch }}
+          JF_WORKING_DIR: ./testdata/projects/noIssuesProject
           JF_FAIL: "FALSE"
           JFROG_CLI_LOG_LEVEL: "DEBUG"
         with:


### PR DESCRIPTION
The OIDC test should scan a test project with no issues (noIssuesProject) instead of scanning the entire frogbot codebase. Without JF_WORKING_DIR, the test scans the root directory, finds real vulnerabilities, and posts comments to PRs.

This restores the behavior from dev branch where JF_WORKING_DIR points to ./testdata/projects/noIssuesProject.

Fixes unintended PR comments during OIDC integration tests.

- [x] All [tests](https://github.com/jfrog/frogbot#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
- [ ] Update [documentation](https://github.com/jfrog/documentation) about new features / new supported technologies
---

