### PR TITLE
Adding JF_USE_CONFIG_PROFILE to scan-pr and scan-repo

### DIFF
--- a/.github/workflows/frogbot-scan-pull-request.yml
+++ b/.github/workflows/frogbot-scan-pull-request.yml
@@ -27,6 +27,8 @@ jobs:
           # The GitHub token is automatically generated for the job
           JF_GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+          JF_USE_CONFIG_PROFILE: true
+
           # [Optional, default: https://api.github.com]
           # API endpoint to GitHub
           # JF_GIT_API_ENDPOINT: https://github.example.com

--- a/.github/workflows/frogbot-scan-repository.yml
+++ b/.github/workflows/frogbot-scan-repository.yml
@@ -36,6 +36,8 @@ jobs:
           # The name of the branch on which Frogbot will perform the scan
           JF_GIT_BASE_BRANCH: ${{ matrix.branch }}
 
+          JF_USE_CONFIG_PROFILE: true
+
           # [Optional, default: https://api.github.com]
           # API endpoint to GitHub
           # JF_GIT_API_ENDPOINT: https://github.example.com


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/frogbot#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] Update [documentation](https://github.com/jfrog/documentation) about new features / new supported technologies
---

Adding usage of config profile for frogbot's scan-pr and scan-repo.
We need it in order to exclude paths for some scanners to ignore tests files