### PR TITLE
Removing 'source results only' possibility from PR scan

### DIFF
--- a/scanpullrequest/scanpullrequest.go
+++ b/scanpullrequest/scanpullrequest.go
@@ -170,13 +170,6 @@ func auditPullRequestSourceCode(repoConfig *utils.Repository, scanDetails *utils
 	}
 	// Set JAS output flags based on the scan results
 	repoConfig.OutputWriter.SetJasOutputFlags(scanResults.EntitledForJas, scanResults.HasJasScansResults(jasutils.Applicability))
-
-	if targetBranchWd == "" || scanDetails.ResultsToCompare == nil {
-		// Since we only perform a Diff scan in this flow - if target wd or target results are missing it means something went wrong with the target scan
-		issuesCollection = &issues.ScansIssuesCollection{ScanStatus: getResultScanStatues(scanResults)}
-		err = errors.New("targetBranchWd or target branch scans results are empty")
-		return
-	}
 	filterFailedResultsIfScannersFailuresAreAllowed(scanDetails.ResultsToCompare, scanResults, repoConfig.Params.ConfigProfile.GeneralConfig.FailUponAnyScannerError, sourceBranchWd, targetBranchWd)
 
 	log.Debug("Diff scan - converting to new issues...")


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/frogbot#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] Update [documentation](https://github.com/jfrog/documentation) about new features / new supported technologies
---

This PR simplifies the auditPullRequestSourceCode func.
We remove the case where we enable the target results to be absent, since in the new flow we only performing a diff scan. Therefore:
1) targetBranchWd cannot be empty unless we had an error in creating its temp dir (in this case the error will be thrown in earlier stage)
2) ResultsToCompare must inhabit a value since if no error happened in the target branch scan we always add these results (if we had an error- it would have thrown in earlier stage)

If both exists as they should - we always add the targetWd path to the scanResultsToIssuesCollection func 