### PR TITLE
Fix TestCreateVulnerabilitiesMap tests

### DIFF
--- a/scanrepository/scanrepository_test.go
+++ b/scanrepository/scanrepository_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	services2 "github.com/jfrog/jfrog-client-go/xsc/services"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -14,23 +13,25 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/CycloneDX/cyclonedx-go"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/protocol/packp"
 	"github.com/go-git/go-git/v5/plumbing/protocol/packp/capability"
-
-	"github.com/jfrog/jfrog-cli-security/utils/xsc"
-
 	"github.com/google/go-github/v45/github"
 	biutils "github.com/jfrog/build-info-go/utils"
 	"github.com/jfrog/froggit-go/vcsclient"
 	"github.com/jfrog/froggit-go/vcsutils"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
 	"github.com/jfrog/jfrog-cli-security/utils/formats"
+	"github.com/jfrog/jfrog-cli-security/utils/formats/violationutils"
 	"github.com/jfrog/jfrog-cli-security/utils/results"
+	"github.com/jfrog/jfrog-cli-security/utils/severityutils"
 	"github.com/jfrog/jfrog-cli-security/utils/techutils"
+	"github.com/jfrog/jfrog-cli-security/utils/xsc"
 	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
 	"github.com/jfrog/jfrog-client-go/utils/log"
 	"github.com/jfrog/jfrog-client-go/xray/services"
+	services2 "github.com/jfrog/jfrog-client-go/xsc/services"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -39,6 +40,10 @@ import (
 )
 
 const rootTestDir = "scanrepository"
+
+func floatPtr(f float64) *float64 {
+	return &f
+}
 
 var emptyConfigProfile = services2.ConfigProfile{
 	ProfileName:   "test-profile",
@@ -463,6 +468,7 @@ func TestCreateVulnerabilitiesMap(t *testing.T) {
 
 	testCases := []struct {
 		name        string
+		sbomFile    string // Optional: path to SBOM JSON file to load
 		scanResults *results.SecurityCommandResults
 		expectedMap map[string]*utils.VulnerabilityDetails
 	}{
@@ -474,7 +480,8 @@ func TestCreateVulnerabilitiesMap(t *testing.T) {
 			expectedMap: map[string]*utils.VulnerabilityDetails{},
 		},
 		{
-			name: "Scan results with vulnerabilities and no violations",
+			name:     "Scan results with vulnerabilities and no violations",
+			sbomFile: filepath.Join("..", "testdata", "scanrepository", "sbom_with_vulnerabilities.json"),
 			scanResults: &results.SecurityCommandResults{
 				ResultsMetaData: results.ResultsMetaData{
 					ResultContext: results.ResultContext{IncludeVulnerabilities: true}},
@@ -484,15 +491,14 @@ func TestCreateVulnerabilitiesMap(t *testing.T) {
 					JasResults: &results.JasScansResults{},
 				}},
 			},
+			// axios@1.2.0 has 4 CVEs with fix versions: 1.6.0, 1.7.8, 1.12.0, 1.8.2
+			// Max fix version is 1.12.0
+			// First CVE processed is CVE-2024-57965 (Critical severity - converter sorts by severity)
 			expectedMap: map[string]*utils.VulnerabilityDetails{
-				"vuln1": {
-					SuggestedFixedVersion: "1.9.1",
+				"axios": {
+					SuggestedFixedVersion: "1.12.0",
 					IsDirectDependency:    true,
-					Cves:                  []string{"CVE-2023-1234", "CVE-2023-4321"},
-				},
-				"vuln2": {
-					SuggestedFixedVersion: "2.4.1",
-					Cves:                  []string{"CVE-2022-1234", "CVE-2022-4321"},
+					Cves:                  []string{"CVE-2024-57965"},
 				},
 			},
 		},
@@ -500,22 +506,163 @@ func TestCreateVulnerabilitiesMap(t *testing.T) {
 			name: "Scan results with violations and no vulnerabilities",
 			scanResults: &results.SecurityCommandResults{
 				ResultsMetaData: results.ResultsMetaData{
-					ResultContext: results.ResultContext{IncludeVulnerabilities: true, Watches: []string{"w1"}}},
+					ResultContext: results.ResultContext{IncludeVulnerabilities: true, Watches: []string{"watch1"}}},
+				Targets: []*results.TargetResults{{
+					ScanTarget: results.ScanTarget{Target: "target1"},
+					JasResults: &results.JasScansResults{},
+				}},
+				Violations: &violationutils.Violations{
+					Sca: []violationutils.CveViolation{
+						{
+							ScaViolation: violationutils.ScaViolation{
+								Violation: violationutils.Violation{
+									ViolationId:   "XRAY-1",
+									ViolationType: violationutils.CveViolationType,
+									Severity:      severityutils.Critical,
+									Watch:         "watch1",
+								},
+								ImpactedComponent: results.CreateScaComponentFromXrayCompId("viol1"),
+								DirectComponents:  []formats.ComponentRow{{Name: "viol1", Version: "1.0.0"}},
+								ImpactPaths:       [][]formats.ComponentRow{{{Name: "root"}, {Name: "viol1", Version: "1.0.0"}}},
+							},
+							CveVulnerability: cyclonedx.Vulnerability{
+								BOMRef: "CVE-2023-1234",
+								ID:     "XRAY-1",
+								Ratings: &[]cyclonedx.VulnerabilityRating{
+									{Score: floatPtr(9.1), Method: cyclonedx.ScoringMethodCVSSv3},
+								},
+							},
+							FixedVersions: &[]cyclonedx.AffectedVersions{
+								{Version: "1.9.1", Status: cyclonedx.VulnerabilityStatusNotAffected},
+							},
+						},
+						{
+							ScaViolation: violationutils.ScaViolation{
+								Violation: violationutils.Violation{
+									ViolationId:   "XRAY-1",
+									ViolationType: violationutils.CveViolationType,
+									Severity:      severityutils.Critical,
+									Watch:         "watch1",
+								},
+								ImpactedComponent: results.CreateScaComponentFromXrayCompId("viol1"),
+								DirectComponents:  []formats.ComponentRow{{Name: "viol1", Version: "1.0.0"}},
+								ImpactPaths:       [][]formats.ComponentRow{{{Name: "root"}, {Name: "viol1", Version: "1.0.0"}}},
+							},
+							CveVulnerability: cyclonedx.Vulnerability{
+								BOMRef: "CVE-2023-4321",
+								ID:     "XRAY-1",
+								Ratings: &[]cyclonedx.VulnerabilityRating{
+									{Score: floatPtr(8.9), Method: cyclonedx.ScoringMethodCVSSv3},
+								},
+							},
+							FixedVersions: &[]cyclonedx.AffectedVersions{
+								{Version: "1.9.1", Status: cyclonedx.VulnerabilityStatusNotAffected},
+							},
+						},
+						{
+							ScaViolation: violationutils.ScaViolation{
+								Violation: violationutils.Violation{
+									ViolationId:   "XRAY-2",
+									ViolationType: violationutils.CveViolationType,
+									Severity:      severityutils.High,
+									Watch:         "watch1",
+								},
+								ImpactedComponent: results.CreateScaComponentFromXrayCompId("viol2"),
+								DirectComponents:  []formats.ComponentRow{{Name: "viol2", Version: "2.0.0"}},
+								ImpactPaths:       [][]formats.ComponentRow{{{Name: "root"}, {Name: "viol1", Version: "1.0.0"}, {Name: "viol2", Version: "2.0.0"}}},
+							},
+							CveVulnerability: cyclonedx.Vulnerability{
+								BOMRef: "CVE-2022-1234",
+								ID:     "XRAY-2",
+								Ratings: &[]cyclonedx.VulnerabilityRating{
+									{Score: floatPtr(7.1), Method: cyclonedx.ScoringMethodCVSSv3},
+								},
+							},
+							FixedVersions: &[]cyclonedx.AffectedVersions{
+								{Version: "2.4.1", Status: cyclonedx.VulnerabilityStatusNotAffected},
+							},
+						},
+						{
+							ScaViolation: violationutils.ScaViolation{
+								Violation: violationutils.Violation{
+									ViolationId:   "XRAY-2",
+									ViolationType: violationutils.CveViolationType,
+									Severity:      severityutils.High,
+									Watch:         "watch1",
+								},
+								ImpactedComponent: results.CreateScaComponentFromXrayCompId("viol2"),
+								DirectComponents:  []formats.ComponentRow{{Name: "viol2", Version: "2.0.0"}},
+								ImpactPaths:       [][]formats.ComponentRow{{{Name: "root"}, {Name: "viol1", Version: "1.0.0"}, {Name: "viol2", Version: "2.0.0"}}},
+							},
+							CveVulnerability: cyclonedx.Vulnerability{
+								BOMRef: "CVE-2022-4321",
+								ID:     "XRAY-2",
+								Ratings: &[]cyclonedx.VulnerabilityRating{
+									{Score: floatPtr(7.9), Method: cyclonedx.ScoringMethodCVSSv3},
+								},
+							},
+							FixedVersions: &[]cyclonedx.AffectedVersions{
+								{Version: "2.4.1", Status: cyclonedx.VulnerabilityStatusNotAffected},
+							},
+						},
+					},
+				},
+			},
+			expectedMap: map[string]*utils.VulnerabilityDetails{
+				"viol1": {
+					SuggestedFixedVersion: "1.9.1",
+					IsDirectDependency:    true,
+					Cves:                  []string{"CVE-2023-1234"},
+				},
+				"viol2": {
+					SuggestedFixedVersion: "2.4.1",
+					IsDirectDependency:    false,
+					Cves:                  []string{"CVE-2022-1234"},
+				},
+			},
+		},
+		{
+			name:     "Multiple vulnerabilities on same package selects max fix version",
+			sbomFile: filepath.Join("..", "testdata", "scanrepository", "sbom_multiple_vulns_same_pkg.json"),
+			scanResults: &results.SecurityCommandResults{
+				ResultsMetaData: results.ResultsMetaData{
+					ResultContext: results.ResultContext{IncludeVulnerabilities: true}},
 				Targets: []*results.TargetResults{{
 					ScanTarget: results.ScanTarget{Target: "target1"},
 					ScaResults: &results.ScaScanResults{},
 					JasResults: &results.JasScansResults{},
 				}},
 			},
+			// shared-pkg@1.0.0 has 3 CVEs with fix versions: 1.5.0, 1.8.0, 1.6.0
+			// Max fix version is 1.8.0
+			// First CVE processed is CVE-2023-2222 (High severity - converter sorts by severity)
 			expectedMap: map[string]*utils.VulnerabilityDetails{
-				"viol1": {
-					SuggestedFixedVersion: "1.9.1",
+				"shared-pkg": {
+					SuggestedFixedVersion: "1.8.0",
 					IsDirectDependency:    true,
-					Cves:                  []string{"CVE-2023-1234", "CVE-2023-4321"},
+					Cves:                  []string{"CVE-2023-2222"},
 				},
-				"viol2": {
-					SuggestedFixedVersion: "2.4.1",
-					Cves:                  []string{"CVE-2022-1234", "CVE-2022-4321"},
+			},
+		},
+		{
+			name:     "Vulnerability with no fixed version is not added to map",
+			sbomFile: filepath.Join("..", "testdata", "scanrepository", "sbom_no_fix_version.json"),
+			scanResults: &results.SecurityCommandResults{
+				ResultsMetaData: results.ResultsMetaData{
+					ResultContext: results.ResultContext{IncludeVulnerabilities: true}},
+				Targets: []*results.TargetResults{{
+					ScanTarget: results.ScanTarget{Target: "target1"},
+					ScaResults: &results.ScaScanResults{},
+					JasResults: &results.JasScansResults{},
+				}},
+			},
+			// no-fix-pkg has CVE-2023-9999 with NO fix version - should not be in map
+			// has-fix-pkg has CVE-2023-8888 with fix version 2.5.0 - should be in map
+			expectedMap: map[string]*utils.VulnerabilityDetails{
+				"has-fix-pkg": {
+					SuggestedFixedVersion: "2.5.0",
+					IsDirectDependency:    true,
+					Cves:                  []string{"CVE-2023-8888"},
 				},
 			},
 		},
@@ -523,11 +670,25 @@ func TestCreateVulnerabilitiesMap(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
+			// Load SBOM from file if specified
+			if testCase.sbomFile != "" {
+				sbomData, err := os.ReadFile(testCase.sbomFile)
+				require.NoError(t, err, "Failed to read SBOM file")
+				var sbom cyclonedx.BOM
+				err = json.Unmarshal(sbomData, &sbom)
+				require.NoError(t, err, "Failed to unmarshal SBOM")
+				// Set the SBOM in the first target's ScaResults
+				if len(testCase.scanResults.Targets) > 0 && testCase.scanResults.Targets[0].ScaResults != nil {
+					testCase.scanResults.Targets[0].ScaResults.Sbom = &sbom
+				}
+			}
+
 			fixVersionsMap, err := cfp.createVulnerabilitiesMap(false, testCase.scanResults)
 			assert.NoError(t, err)
+			assert.Equal(t, len(testCase.expectedMap), len(fixVersionsMap), "Map size mismatch")
 			for name, expectedVuln := range testCase.expectedMap {
 				actualVuln, exists := fixVersionsMap[name]
-				require.True(t, exists)
+				require.True(t, exists, "Expected key %q not found in map", name)
 				assert.Equal(t, expectedVuln.IsDirectDependency, actualVuln.IsDirectDependency)
 				assert.Equal(t, expectedVuln.SuggestedFixedVersion, actualVuln.SuggestedFixedVersion)
 				assert.ElementsMatch(t, expectedVuln.Cves, actualVuln.Cves)

--- a/testdata/scanrepository/sbom_multiple_vulns_same_pkg.json
+++ b/testdata/scanrepository/sbom_multiple_vulns_same_pkg.json
@@ -1,0 +1,78 @@
+{
+  "$schema" : "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat" : "CycloneDX",
+  "specVersion" : "1.6",
+  "version" : 1,
+  "metadata" : {
+    "component" : {
+      "bom-ref" : "file:test-root",
+      "type" : "file",
+      "name" : "test-project",
+      "version" : "1.0.0"
+    }
+  },
+  "components" : [ {
+    "bom-ref" : "pkg:npm/test-project@1.0.0",
+    "type" : "library",
+    "name" : "test-project",
+    "version" : "1.0.0",
+    "purl" : "pkg:npm/test-project@1.0.0",
+    "properties" : [ {
+      "name" : "jfrog:dependency:type",
+      "value" : "root"
+    } ]
+  }, {
+    "bom-ref" : "pkg:npm/shared-pkg@1.0.0",
+    "type" : "library",
+    "name" : "shared-pkg",
+    "version" : "1.0.0",
+    "purl" : "pkg:npm/shared-pkg@1.0.0",
+    "properties" : [ {
+      "name" : "jfrog:dependency:type",
+      "value" : "direct"
+    } ]
+  } ],
+  "dependencies" : [ {
+    "ref" : "file:test-root",
+    "dependsOn" : [ "pkg:npm/test-project@1.0.0" ]
+  }, {
+    "ref" : "pkg:npm/test-project@1.0.0",
+    "dependsOn" : [ "pkg:npm/shared-pkg@1.0.0" ]
+  }, {
+    "ref" : "pkg:npm/shared-pkg@1.0.0"
+  } ],
+  "vulnerabilities" : [ {
+    "bom-ref" : "CVE-2023-1111",
+    "id" : "CVE-2023-1111",
+    "source" : { "name" : "JFrog Catalog" },
+    "ratings" : [ { "severity" : "medium" } ],
+    "cwes" : [ 79 ],
+    "description" : "First vulnerability with fix 1.5.0",
+    "affects" : [ {
+      "ref" : "pkg:npm/shared-pkg@1.0.0",
+      "versions" : [ { "version" : "1.5.0", "status" : "unaffected" } ]
+    } ]
+  }, {
+    "bom-ref" : "CVE-2023-2222",
+    "id" : "CVE-2023-2222",
+    "source" : { "name" : "JFrog Catalog" },
+    "ratings" : [ { "severity" : "high" } ],
+    "cwes" : [ 89 ],
+    "description" : "Second vulnerability with fix 1.8.0 (highest)",
+    "affects" : [ {
+      "ref" : "pkg:npm/shared-pkg@1.0.0",
+      "versions" : [ { "version" : "1.8.0", "status" : "unaffected" } ]
+    } ]
+  }, {
+    "bom-ref" : "CVE-2023-3333",
+    "id" : "CVE-2023-3333",
+    "source" : { "name" : "JFrog Catalog" },
+    "ratings" : [ { "severity" : "low" } ],
+    "cwes" : [ 200 ],
+    "description" : "Third vulnerability with fix 1.6.0",
+    "affects" : [ {
+      "ref" : "pkg:npm/shared-pkg@1.0.0",
+      "versions" : [ { "version" : "1.6.0", "status" : "unaffected" } ]
+    } ]
+  } ]
+}

--- a/testdata/scanrepository/sbom_no_fix_version.json
+++ b/testdata/scanrepository/sbom_no_fix_version.json
@@ -1,0 +1,78 @@
+{
+  "$schema" : "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat" : "CycloneDX",
+  "specVersion" : "1.6",
+  "version" : 1,
+  "metadata" : {
+    "component" : {
+      "bom-ref" : "file:test-root",
+      "type" : "file",
+      "name" : "test-project",
+      "version" : "1.0.0"
+    }
+  },
+  "components" : [ {
+    "bom-ref" : "pkg:npm/test-project@1.0.0",
+    "type" : "library",
+    "name" : "test-project",
+    "version" : "1.0.0",
+    "purl" : "pkg:npm/test-project@1.0.0",
+    "properties" : [ {
+      "name" : "jfrog:dependency:type",
+      "value" : "root"
+    } ]
+  }, {
+    "bom-ref" : "pkg:npm/no-fix-pkg@1.0.0",
+    "type" : "library",
+    "name" : "no-fix-pkg",
+    "version" : "1.0.0",
+    "purl" : "pkg:npm/no-fix-pkg@1.0.0",
+    "properties" : [ {
+      "name" : "jfrog:dependency:type",
+      "value" : "direct"
+    } ]
+  }, {
+    "bom-ref" : "pkg:npm/has-fix-pkg@2.0.0",
+    "type" : "library",
+    "name" : "has-fix-pkg",
+    "version" : "2.0.0",
+    "purl" : "pkg:npm/has-fix-pkg@2.0.0",
+    "properties" : [ {
+      "name" : "jfrog:dependency:type",
+      "value" : "direct"
+    } ]
+  } ],
+  "dependencies" : [ {
+    "ref" : "file:test-root",
+    "dependsOn" : [ "pkg:npm/test-project@1.0.0" ]
+  }, {
+    "ref" : "pkg:npm/test-project@1.0.0",
+    "dependsOn" : [ "pkg:npm/no-fix-pkg@1.0.0", "pkg:npm/has-fix-pkg@2.0.0" ]
+  }, {
+    "ref" : "pkg:npm/no-fix-pkg@1.0.0"
+  }, {
+    "ref" : "pkg:npm/has-fix-pkg@2.0.0"
+  } ],
+  "vulnerabilities" : [ {
+    "bom-ref" : "CVE-2023-9999",
+    "id" : "CVE-2023-9999",
+    "source" : { "name" : "JFrog Catalog" },
+    "ratings" : [ { "severity" : "high" } ],
+    "cwes" : [ 79 ],
+    "description" : "Vulnerability with NO fix version - should not be added to map",
+    "affects" : [ {
+      "ref" : "pkg:npm/no-fix-pkg@1.0.0"
+    } ]
+  }, {
+    "bom-ref" : "CVE-2023-8888",
+    "id" : "CVE-2023-8888",
+    "source" : { "name" : "JFrog Catalog" },
+    "ratings" : [ { "severity" : "medium" } ],
+    "cwes" : [ 89 ],
+    "description" : "Vulnerability WITH fix version - should be added to map",
+    "affects" : [ {
+      "ref" : "pkg:npm/has-fix-pkg@2.0.0",
+      "versions" : [ { "version" : "2.5.0", "status" : "unaffected" } ]
+    } ]
+  } ]
+}

--- a/testdata/scanrepository/sbom_with_vulnerabilities.json
+++ b/testdata/scanrepository/sbom_with_vulnerabilities.json
@@ -1,0 +1,130 @@
+{
+  "$schema" : "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat" : "CycloneDX",
+  "specVersion" : "1.6",
+  "serialNumber" : "urn:uuid:bb4d6226-dd2e-49a6-aa81-e7162b9d14f1",
+  "version" : 1,
+  "metadata" : {
+    "component" : {
+      "bom-ref" : "file:test-root",
+      "type" : "file",
+      "name" : "test-project",
+      "version" : "1.0.0"
+    }
+  },
+  "components" : [ {
+    "bom-ref" : "pkg:npm/test-project@1.0.0",
+    "type" : "library",
+    "name" : "test-project",
+    "version" : "1.0.0",
+    "purl" : "pkg:npm/test-project@1.0.0",
+    "properties" : [ {
+      "name" : "jfrog:dependency:type",
+      "value" : "root"
+    } ]
+  }, {
+    "bom-ref" : "pkg:npm/axios@1.2.0",
+    "type" : "library",
+    "name" : "axios",
+    "version" : "1.2.0",
+    "purl" : "pkg:npm/axios@1.2.0",
+    "properties" : [ {
+      "name" : "jfrog:dependency:type",
+      "value" : "direct"
+    } ]
+  } ],
+  "dependencies" : [ {
+    "ref" : "file:test-root",
+    "dependsOn" : [ "pkg:npm/test-project@1.0.0" ]
+  }, {
+    "ref" : "pkg:npm/test-project@1.0.0",
+    "dependsOn" : [ "pkg:npm/axios@1.2.0" ]
+  }, {
+    "ref" : "pkg:npm/axios@1.2.0"
+  } ],
+  "vulnerabilities" : [ {
+    "bom-ref" : "CVE-2023-45857",
+    "id" : "CVE-2023-45857",
+    "source" : {
+      "name" : "JFrog Catalog"
+    },
+    "ratings" : [ {
+      "source" : {
+        "name" : "JFrog Catalog"
+      },
+      "severity" : "medium"
+    } ],
+    "cwes" : [ 352 ],
+    "description" : "An issue discovered in Axios 0.8.1 through 1.5.1 inadvertently reveals the confidential XSRF-TOKEN.",
+    "affects" : [ {
+      "ref" : "pkg:npm/axios@1.2.0",
+      "versions" : [ {
+        "version" : "1.6.0",
+        "status" : "unaffected"
+      } ]
+    } ]
+  }, {
+    "bom-ref" : "CVE-2024-57965",
+    "id" : "CVE-2024-57965",
+    "source" : {
+      "name" : "JFrog Catalog"
+    },
+    "ratings" : [ {
+      "source" : {
+        "name" : "JFrog Catalog"
+      },
+      "severity" : "critical"
+    } ],
+    "cwes" : [ 346 ],
+    "description" : "In axios before 1.7.8, lib/helpers/isURLSameOrigin.js does not use a URL object.",
+    "affects" : [ {
+      "ref" : "pkg:npm/axios@1.2.0",
+      "versions" : [ {
+        "version" : "1.7.8",
+        "status" : "unaffected"
+      } ]
+    } ]
+  }, {
+    "bom-ref" : "CVE-2025-58754",
+    "id" : "CVE-2025-58754",
+    "source" : {
+      "name" : "JFrog Catalog"
+    },
+    "ratings" : [ {
+      "source" : {
+        "name" : "JFrog Catalog"
+      },
+      "severity" : "high"
+    } ],
+    "cwes" : [ 770 ],
+    "description" : "Axios memory exhaustion vulnerability via malicious data: URIs.",
+    "affects" : [ {
+      "ref" : "pkg:npm/axios@1.2.0",
+      "versions" : [ {
+        "version" : "1.12.0",
+        "status" : "unaffected"
+      } ]
+    } ]
+  }, {
+    "bom-ref" : "CVE-2025-27152",
+    "id" : "CVE-2025-27152",
+    "source" : {
+      "name" : "JFrog Catalog"
+    },
+    "ratings" : [ {
+      "source" : {
+        "name" : "JFrog Catalog"
+      },
+      "severity" : "medium"
+    } ],
+    "cwes" : [ 918 ],
+    "description" : "SSRF vulnerability when passing absolute URLs to axios.",
+    "affects" : [ {
+      "ref" : "pkg:npm/axios@1.2.0",
+      "versions" : [ {
+        "version" : "1.8.2",
+        "status" : "unaffected"
+      } ]
+    } ]
+  } ]
+}


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/frogbot#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] Update [documentation](https://github.com/jfrog/documentation) about new features / new supported technologies
---

- Fix all test cases that were corrupted due to V3 changes
- Update vulnerability tests to use real SBOM structure from testdata files
- Add SBOM testdata files with proper JFrog catalog format:
  - sbom_with_vulnerabilities.json: Main vulnerability test with axios CVEs
  - sbom_multiple_vulns_same_pkg.json: Tests max version selection logic
  - sbom_no_fix_version.json: Tests that vulns without fixes are excluded
- Update violations test to use SecurityCommandResults.Violations field
- Add support for loading SBOM from testdata files in test runner

Test cases now properly validate:
- Vulnerabilities processed from SBOM format
- Violations processed from Violations field
- Max fix version selection when multiple CVEs affect same package
- Vulnerabilities without fix versions are not added to map