### PR TITLE
fix test due to scan-pr environment enforcement

### DIFF
--- a/.github/workflows/oidc-test.yml
+++ b/.github/workflows/oidc-test.yml
@@ -1,8 +1,10 @@
 name: "OIDC Test"
 on:
   push:
-  pull_request_target:
-    types: [ labeled ]
+    branches:
+      - dev
+      - v3_er
+      - master
 permissions:
   contents: write
   pull-requests: write
@@ -10,7 +12,6 @@ permissions:
   id-token: write
 jobs:
   oidc-test:
-    if: contains(github.event.pull_request.labels.*.name, 'safe to test') || github.event_name == 'push'
     name: OIDC-Access integration test (${{ matrix.os }})
     strategy:
       fail-fast: false


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/frogbot#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] Update [documentation](https://github.com/jfrog/documentation) about new features / new supported technologies
---

This PR changes the trigger of the OIDC yml test for 2 reasons:
1) The tests runs scan-pr due to the pull_request_target trigger. since we not enfore environment with reviewers on every scan-pr run we will have to approve this test all the time -not required
2) we dont really care what flow we run as the intention os to only validate the OIDC token so adding another approval step is redundent
3) Sicne the trigger was pull_reqest_target the test code that runs on every pr, doesnt really reflect the PR changes even if those were made in the test. So there is no real value to add this on every PR and we can reduce this to be run on every push