### PR TITLE
Publish Scan Results to Gitlab Dashboards

### DIFF
--- a/scanrepository/scanrepository.go
+++ b/scanrepository/scanrepository.go
@@ -157,14 +157,13 @@ func (sr *ScanRepositoryCmd) scanAndFixBranch(repository *utils.Repository) (tot
 
 	if repository.Params.Git.GitProvider == vcsutils.GitLab && repository.Params.Git.GitlabScanResultsOutputDir != "" {
 		log.Debug(fmt.Sprintf("Trying to save scan results to directory: %s", repository.Params.Git.GitlabScanResultsOutputDir))
-		if err = utils.WriteScanResultsToDir(repository.Params.Git.GitlabScanResultsOutputDir, scanResults, sr.scanDetails.StartTime); err != nil {
-			log.Warn(fmt.Sprintf("Failed to write scan results to directory: %s", err.Error()))
+		if writeErr := utils.WriteScanResultsToDir(repository.Params.Git.GitlabScanResultsOutputDir, scanResults, sr.scanDetails.StartTime); writeErr != nil {
+			log.Warn(fmt.Sprintf("Failed to write scan results to directory: %s", writeErr.Error()))
 		}
-		return
 	}
 
 	if !repository.Params.FrogbotConfig.CreateAutoFixPr {
-		log.Info(fmt.Sprintf("This command is running in detection mode only. To enable automatic fixing of issues, set the '%s' flag under the repository's coniguration settings in Jfrog platform", createAutoFixPrConfigNameInProfile))
+		log.Info(fmt.Sprintf("This command is running in detection mode only. To enable automatic fixing of issues, set the '%s' flag under the repository's configuration settings in Jfrog platform", createAutoFixPrConfigNameInProfile))
 		return totalFindings, nil
 	}
 

--- a/scanrepository/scanrepository.go
+++ b/scanrepository/scanrepository.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/jfrog/frogbot/v2/packageupdaters"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/jfrog/frogbot/v2/packageupdaters"
 
 	"github.com/go-git/go-git/v5"
 	biutils "github.com/jfrog/build-info-go/utils"
@@ -153,6 +154,14 @@ func (sr *ScanRepositoryCmd) scanAndFixBranch(repository *utils.Repository) (tot
 	}()
 	totalFindings = getTotalFindingsFromScanResults(scanResults)
 	sr.uploadResultsToGithubDashboardsIfNeeded(repository, scanResults)
+
+	if repository.Params.Git.GitProvider == vcsutils.GitLab && repository.Params.Git.GitlabScanResultsOutputDir != "" {
+		log.Debug(fmt.Sprintf("Trying to save scan results to directory: %s", repository.Params.Git.GitlabScanResultsOutputDir))
+		if err = utils.WriteScanResultsToDir(repository.Params.Git.GitlabScanResultsOutputDir, scanResults, sr.scanDetails.StartTime); err != nil {
+			log.Warn(fmt.Sprintf("Failed to write scan results to directory: %s", err.Error()))
+		}
+		return
+	}
 
 	if !repository.Params.FrogbotConfig.CreateAutoFixPr {
 		log.Info(fmt.Sprintf("This command is running in detection mode only. To enable automatic fixing of issues, set the '%s' flag under the repository's coniguration settings in Jfrog platform", createAutoFixPrConfigNameInProfile))

--- a/scanrepository/scanrepository.go
+++ b/scanrepository/scanrepository.go
@@ -154,13 +154,7 @@ func (sr *ScanRepositoryCmd) scanAndFixBranch(repository *utils.Repository) (tot
 	}()
 	totalFindings = getTotalFindingsFromScanResults(scanResults)
 	sr.uploadResultsToGithubDashboardsIfNeeded(repository, scanResults)
-
-	if repository.Params.Git.GitProvider == vcsutils.GitLab && repository.Params.Git.GitlabScanResultsOutputDir != "" {
-		log.Debug(fmt.Sprintf("Trying to save scan results to directory: %s", repository.Params.Git.GitlabScanResultsOutputDir))
-		if writeErr := utils.WriteScanResultsToDir(repository.Params.Git.GitlabScanResultsOutputDir, scanResults, sr.scanDetails.StartTime); writeErr != nil {
-			log.Warn(fmt.Sprintf("Failed to write scan results to directory: %s", writeErr.Error()))
-		}
-	}
+	sr.uploadGitLabScanResultsIfNeeded(repository, scanResults)
 
 	if !repository.Params.FrogbotConfig.CreateAutoFixPr {
 		log.Info(fmt.Sprintf("This command is running in detection mode only. To enable automatic fixing of issues, set the '%s' flag under the repository's configuration settings in Jfrog platform", createAutoFixPrConfigNameInProfile))
@@ -191,6 +185,16 @@ func getTotalFindingsFromScanResults(scanResults *results.SecurityCommandResults
 		findingCount = summary.GetTotalVulnerabilities()
 	}
 	return findingCount
+}
+
+func (sr *ScanRepositoryCmd) uploadGitLabScanResultsIfNeeded(repository *utils.Repository, scanResults *results.SecurityCommandResults) {
+	if repository.Params.Git.GitProvider != vcsutils.GitLab || repository.Params.Git.GitlabScanResultsOutputDir == "" {
+		return
+	}
+	log.Debug(fmt.Sprintf("Trying to save scan results to directory: %s", repository.Params.Git.GitlabScanResultsOutputDir))
+	if writeErr := utils.WriteScanResultsToGitlabDir(repository.Params.Git.GitlabScanResultsOutputDir, scanResults, sr.scanDetails.StartTime); writeErr != nil {
+		log.Warn(fmt.Sprintf("Failed to write scan results to directory: %s", writeErr.Error()))
+	}
 }
 
 func (sr *ScanRepositoryCmd) uploadResultsToGithubDashboardsIfNeeded(repository *utils.Repository, scanResults *results.SecurityCommandResults) {

--- a/utils/consts.go
+++ b/utils/consts.go
@@ -42,10 +42,11 @@ const (
 	GitDependencyGraphSubmissionEnv = "JF_UPLOAD_SBOM_TO_VCS"
 
 	//#nosec G101 -- False positive - no hardcoded credentials.
-	GitTokenEnv         = "JF_GIT_TOKEN"
-	GitBaseBranchEnv    = "JF_GIT_BASE_BRANCH"
-	GitPullRequestIDEnv = "JF_GIT_PULL_REQUEST_ID"
-	GitApiEndpointEnv   = "JF_GIT_API_ENDPOINT"
+	GitTokenEnv                   = "JF_GIT_TOKEN"
+	GitBaseBranchEnv              = "JF_GIT_BASE_BRANCH"
+	GitPullRequestIDEnv           = "JF_GIT_PULL_REQUEST_ID"
+	GitApiEndpointEnv             = "JF_GIT_API_ENDPOINT"
+	GitlabScanResultsOutputDirEnv = "JF_SCAN_RESULTS_OUTPUT_DIR"
 
 	// Placeholders for templates
 	PackagePlaceHolder    = "{IMPACTED_PACKAGE}"

--- a/utils/consts.go
+++ b/utils/consts.go
@@ -43,10 +43,11 @@ const (
 	GitDependencyGraphSubmissionEnv = "JF_UPLOAD_SBOM_TO_VCS"
 
 	//#nosec G101 -- False positive - no hardcoded credentials.
-	GitTokenEnv         = "JF_GIT_TOKEN"
-	GitBaseBranchEnv    = "JF_GIT_BASE_BRANCH"
-	GitPullRequestIDEnv = "JF_GIT_PULL_REQUEST_ID"
-	GitApiEndpointEnv   = "JF_GIT_API_ENDPOINT"
+	GitTokenEnv                   = "JF_GIT_TOKEN"
+	GitBaseBranchEnv              = "JF_GIT_BASE_BRANCH"
+	GitPullRequestIDEnv           = "JF_GIT_PULL_REQUEST_ID"
+	GitApiEndpointEnv             = "JF_GIT_API_ENDPOINT"
+	GitlabScanResultsOutputDirEnv = "JF_SCAN_RESULTS_OUTPUT_DIR"
 
 	// Placeholders for templates
 	PackagePlaceHolder    = "{IMPACTED_PACKAGE}"

--- a/utils/getconfiguration.go
+++ b/utils/getconfiguration.go
@@ -68,12 +68,13 @@ func (jp *JFrogPlatform) setJfProjectKeyIfExists() (err error) {
 type Git struct {
 	GitProvider vcsutils.VcsProvider
 	vcsclient.VcsInfo
-	RepoOwner          string
-	RepoName           string
-	Branches           []string
-	PullRequestDetails vcsclient.PullRequestInfo
-	RepositoryCloneUrl string
-	UploadSbomToVcs    *bool
+	RepoOwner                  string
+	RepoName                   string
+	Branches                   []string
+	PullRequestDetails         vcsclient.PullRequestInfo
+	RepositoryCloneUrl         string
+	UploadSbomToVcs            *bool
+	GitlabScanResultsOutputDir string
 }
 
 func (g *Git) GetRepositoryHttpsCloneUrl(gitClient vcsclient.VcsClient) (string, error) {
@@ -95,6 +96,7 @@ func (g *Git) setDefaultsIfNeeded(gitParamsFromEnv *Git, commandName string) (er
 	g.VcsInfo = gitParamsFromEnv.VcsInfo
 	g.PullRequestDetails = gitParamsFromEnv.PullRequestDetails
 	g.RepoName = gitParamsFromEnv.RepoName
+	g.GitlabScanResultsOutputDir = gitParamsFromEnv.GitlabScanResultsOutputDir
 
 	if commandName == ScanPullRequest {
 		if gitParamsFromEnv.PullRequestDetails.ID == 0 {
@@ -424,6 +426,8 @@ func extractGitParamsFromEnvs() (*Git, error) {
 		}
 		gitEnvParams.PullRequestDetails = vcsclient.PullRequestInfo{ID: int64(convertedPrId)}
 	}
+
+	gitEnvParams.GitlabScanResultsOutputDir = getTrimmedEnv(GitlabScanResultsOutputDirEnv)
 
 	return gitEnvParams, nil
 }

--- a/utils/getconfiguration.go
+++ b/utils/getconfiguration.go
@@ -69,12 +69,13 @@ func (jp *JFrogPlatform) setJfProjectKeyIfExists() (err error) {
 type Git struct {
 	GitProvider vcsutils.VcsProvider
 	vcsclient.VcsInfo
-	RepoOwner          string
-	RepoName           string
-	Branches           []string
-	PullRequestDetails vcsclient.PullRequestInfo
-	RepositoryCloneUrl string
-	UploadSbomToVcs    *bool
+	RepoOwner                  string
+	RepoName                   string
+	Branches                   []string
+	PullRequestDetails         vcsclient.PullRequestInfo
+	RepositoryCloneUrl         string
+	UploadSbomToVcs            *bool
+	GitlabScanResultsOutputDir string
 }
 
 func (g *Git) GetRepositoryHttpsCloneUrl(gitClient vcsclient.VcsClient) (string, error) {
@@ -96,6 +97,7 @@ func (g *Git) setDefaultsIfNeeded(gitParamsFromEnv *Git, commandName string) (er
 	g.VcsInfo = gitParamsFromEnv.VcsInfo
 	g.PullRequestDetails = gitParamsFromEnv.PullRequestDetails
 	g.RepoName = gitParamsFromEnv.RepoName
+	g.GitlabScanResultsOutputDir = gitParamsFromEnv.GitlabScanResultsOutputDir
 
 	if commandName == ScanPullRequest {
 		if gitParamsFromEnv.PullRequestDetails.ID == 0 {
@@ -427,6 +429,8 @@ func extractGitParamsFromEnvs() (*Git, error) {
 		}
 		gitEnvParams.PullRequestDetails = vcsclient.PullRequestInfo{ID: int64(convertedPrId)}
 	}
+
+	gitEnvParams.GitlabScanResultsOutputDir = getTrimmedEnv(GitlabScanResultsOutputDirEnv)
 
 	return gitEnvParams, nil
 }

--- a/utils/gitlabreport/cyclonedx_gitlab_reachability.go
+++ b/utils/gitlabreport/cyclonedx_gitlab_reachability.go
@@ -69,6 +69,15 @@ func EnrichCycloneDXBOMForGitLabReachability(bom *cyclonedx.BOM, scanResults *re
 		mergeRowReachability(depInfo, &simpleJSON.SecurityViolations[i])
 	}
 
+	// When the whole scan uses one lockfile (typical), set it on metadata too so GitLab can
+	// correlate SBOM reachability with dependency-scanning findings (per taxonomy).
+	if unique := uniqueNonEmptyInputFilesFromDepInfo(depInfo); len(unique) == 1 {
+		bom.Metadata.Properties = cdxutils.AppendProperties(bom.Metadata.Properties, cyclonedx.Property{
+			Name:  gitlabDependencyScanningInputFilePath,
+			Value: unique[0],
+		})
+	}
+
 	if bom.Metadata.Component != nil {
 		walkComponentTree(bom.Metadata.Component, depInfo)
 	}
@@ -79,6 +88,32 @@ func EnrichCycloneDXBOMForGitLabReachability(bom *cyclonedx.BOM, scanResults *re
 type depReachInfo struct {
 	rank      reachRank
 	inputFile string
+}
+
+func uniqueNonEmptyInputFilesFromDepInfo(depInfo map[string]*depReachInfo) []string {
+	seen := make(map[string]struct{})
+	for _, info := range depInfo {
+		if info == nil || info.rank <= reachNone {
+			continue
+		}
+		f := strings.TrimSpace(info.inputFile)
+		if f == "" {
+			continue
+		}
+		seen[f] = struct{}{}
+	}
+	if len(seen) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(seen))
+	for f := range seen {
+		out = append(out, f)
+	}
+	if len(out) == 1 {
+		return out
+	}
+	// Multiple lockfiles in one BOM: do not guess metadata-level path.
+	return nil
 }
 
 func mergeRowReachability(depInfo map[string]*depReachInfo, v *formats.VulnerabilityOrViolationRow) {

--- a/utils/gitlabreport/cyclonedx_gitlab_reachability.go
+++ b/utils/gitlabreport/cyclonedx_gitlab_reachability.go
@@ -1,0 +1,206 @@
+package gitlabreport
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/CycloneDX/cyclonedx-go"
+	"github.com/jfrog/jfrog-cli-security/utils/formats"
+	"github.com/jfrog/jfrog-cli-security/utils/formats/cdxutils"
+	"github.com/jfrog/jfrog-cli-security/utils/jasutils"
+	"github.com/jfrog/jfrog-cli-security/utils/results"
+	"github.com/jfrog/jfrog-cli-security/utils/results/conversion"
+	"github.com/jfrog/jfrog-client-go/utils/log"
+)
+
+// GitLab documents native "Reachable" (Yes / Not Found / Not Available) from CycloneDX
+// component properties, not from gl-dependency-scanning-report.json details.
+// See: https://docs.gitlab.com/development/sec/cyclonedx_property_taxonomy/
+const (
+	gitlabMetaSchemaVersionProp           = "gitlab:meta:schema_version"
+	gitlabDependencyScanningInputFilePath = "gitlab:dependency_scanning:input_file:path"
+	gitlabDependencyScanningReachability  = "gitlab:dependency_scanning_component:reachability"
+	gitlabReachabilityInUse               = "in_use"
+	gitlabReachabilityNotFound            = "not_found"
+)
+
+// reachRank orders contextual-analysis outcomes for merging multiple findings on one dependency.
+type reachRank int
+
+const (
+	reachNone reachRank = iota
+	reachNotFound
+	reachInUse
+)
+
+// EnrichCycloneDXBOMForGitLabReachability adds GitLab CycloneDX properties so the Security UI
+// "Reachable" field reflects JFrog contextual analysis (applicability): Applicable → in_use (Yes),
+// other assessed outcomes → not_found (Not Found), no applicability data → omit (Not Available).
+//
+// GitLab only merges SBOM reachability into findings when the BOM is uploaded as a CycloneDX
+// report (artifacts:reports:cyclonedx), not as a generic artifact path alone.
+func EnrichCycloneDXBOMForGitLabReachability(bom *cyclonedx.BOM, scanResults *results.SecurityCommandResults) {
+	if bom == nil || scanResults == nil {
+		return
+	}
+	if bom.Metadata == nil {
+		bom.Metadata = &cyclonedx.Metadata{}
+	}
+	bom.Metadata.Properties = cdxutils.AppendProperties(bom.Metadata.Properties, cyclonedx.Property{
+		Name:  gitlabMetaSchemaVersionProp,
+		Value: "1",
+	})
+
+	convertor := conversion.NewCommandResultsConvertor(conversion.ResultConvertParams{
+		IncludeVulnerabilities: true,
+		HasViolationContext:    scanResults.HasViolationContext(),
+	})
+	simpleJSON, err := convertor.ConvertToSimpleJson(scanResults)
+	if err != nil {
+		log.Warn(fmt.Sprintf("GitLab reachability: skipping CycloneDX enrichment, simple JSON conversion failed: %v", err))
+		return
+	}
+
+	depInfo := make(map[string]*depReachInfo)
+	for i := range simpleJSON.Vulnerabilities {
+		mergeRowReachability(depInfo, &simpleJSON.Vulnerabilities[i])
+	}
+	for i := range simpleJSON.SecurityViolations {
+		mergeRowReachability(depInfo, &simpleJSON.SecurityViolations[i])
+	}
+
+	if bom.Metadata.Component != nil {
+		walkComponentTree(bom.Metadata.Component, depInfo)
+	}
+	walkComponentSlice(bom.Components, depInfo)
+}
+
+// depReachInfo holds merged reachability and a manifest path for GitLab SBOM correlation.
+type depReachInfo struct {
+	rank      reachRank
+	inputFile string
+}
+
+func mergeRowReachability(depInfo map[string]*depReachInfo, v *formats.VulnerabilityOrViolationRow) {
+	r, ok := gitlabReachabilityRankForRow(v)
+	if !ok {
+		return
+	}
+	inFile := rowPreferredInputFile(v)
+	for _, key := range rowDependencyKeys(v) {
+		if key == "" {
+			continue
+		}
+		cur := depInfo[key]
+		if cur == nil {
+			cur = &depReachInfo{}
+			depInfo[key] = cur
+		}
+		if r > cur.rank {
+			cur.rank = r
+			if inFile != "" {
+				cur.inputFile = inFile
+			}
+		} else if r == cur.rank && cur.inputFile == "" && inFile != "" {
+			cur.inputFile = inFile
+		}
+	}
+}
+
+// rowPreferredInputFile picks a repo-relative lock/manifest path for gitlab:dependency_scanning:input_file:path.
+func rowPreferredInputFile(v *formats.VulnerabilityOrViolationRow) string {
+	for _, comp := range v.Components {
+		if comp.PreferredLocation != nil {
+			if f := strings.TrimSpace(comp.PreferredLocation.File); f != "" {
+				return f
+			}
+		}
+		for _, ev := range comp.Evidences {
+			if f := strings.TrimSpace(ev.File); f != "" {
+				return f
+			}
+		}
+	}
+	return strings.TrimSpace(manifestFileForTechnology(v.Technology))
+}
+
+func rowDependencyKeys(v *formats.VulnerabilityOrViolationRow) []string {
+	name := strings.TrimSpace(v.ImpactedDependencyName)
+	ver := strings.TrimSpace(v.ImpactedDependencyVersion)
+	if name == "" {
+		return nil
+	}
+	return []string{dependencyReachabilityKey(name, ver)}
+}
+
+func dependencyReachabilityKey(name, version string) string {
+	return name + "\x00" + version
+}
+
+// gitlabReachabilityRankForRow maps aggregated contextual analysis to GitLab reachability ranks.
+func gitlabReachabilityRankForRow(v *formats.VulnerabilityOrViolationRow) (reachRank, bool) {
+	switch rowFinalApplicabilityStatus(v) {
+	case jasutils.NotScanned:
+		return reachNone, false
+	case jasutils.Applicable:
+		return reachInUse, true
+	default:
+		return reachNotFound, true
+	}
+}
+
+func walkComponentSlice(list *[]cyclonedx.Component, depInfo map[string]*depReachInfo) {
+	if list == nil {
+		return
+	}
+	for i := range *list {
+		walkComponentTree(&(*list)[i], depInfo)
+	}
+}
+
+func walkComponentTree(c *cyclonedx.Component, depInfo map[string]*depReachInfo) {
+	if c == nil {
+		return
+	}
+	if info := bestReachInfoForComponent(c, depInfo); info != nil && info.rank > reachNone {
+		if info.inputFile != "" {
+			c.Properties = cdxutils.AppendProperties(c.Properties, cyclonedx.Property{
+				Name:  gitlabDependencyScanningInputFilePath,
+				Value: info.inputFile,
+			})
+		}
+		val := gitlabReachabilityNotFound
+		if info.rank == reachInUse {
+			val = gitlabReachabilityInUse
+		}
+		c.Properties = cdxutils.AppendProperties(c.Properties, cyclonedx.Property{
+			Name:  gitlabDependencyScanningReachability,
+			Value: val,
+		})
+	}
+	walkComponentSlice(c.Components, depInfo)
+}
+
+func bestReachInfoForComponent(c *cyclonedx.Component, depInfo map[string]*depReachInfo) *depReachInfo {
+	var best *depReachInfo
+	for _, key := range componentDependencyMatchKeys(c) {
+		if cur := depInfo[key]; cur != nil && (best == nil || cur.rank > best.rank) {
+			best = cur
+		}
+	}
+	return best
+}
+
+func componentDependencyMatchKeys(c *cyclonedx.Component) []string {
+	name := strings.TrimSpace(c.Name)
+	ver := strings.TrimSpace(c.Version)
+	if name == "" {
+		return nil
+	}
+	var keys []string
+	if g := strings.TrimSpace(c.Group); g != "" {
+		keys = append(keys, dependencyReachabilityKey(g+":"+name, ver))
+	}
+	keys = append(keys, dependencyReachabilityKey(name, ver))
+	return keys
+}

--- a/utils/gitlabreport/cyclonedx_gitlab_reachability.go
+++ b/utils/gitlabreport/cyclonedx_gitlab_reachability.go
@@ -197,6 +197,9 @@ func walkComponentTree(c *cyclonedx.Component, depInfo map[string]*depReachInfo)
 	if c == nil {
 		return
 	}
+	if idx := strings.Index(c.PackageURL, "?"); idx != -1 {
+		c.PackageURL = c.PackageURL[:idx]
+	}
 	if info := bestReachInfoForComponent(c, depInfo); info != nil && info.rank > reachNone {
 		if info.inputFile != "" {
 			c.Properties = cdxutils.AppendProperties(c.Properties, cyclonedx.Property{

--- a/utils/gitlabreport/cyclonedx_gitlab_reachability.go
+++ b/utils/gitlabreport/cyclonedx_gitlab_reachability.go
@@ -68,10 +68,10 @@ func EnrichCycloneDXBOMForGitLabReachability(bom *cyclonedx.BOM, scanResults *re
 
 	// When the whole scan uses one lockfile (typical), set it on metadata too so GitLab can
 	// correlate SBOM reachability with dependency-scanning findings (per taxonomy).
-	if unique := uniqueNonEmptyInputFilesFromDepInfo(depInfo); len(unique) == 1 {
+	if f := uniqueInputFileFromDepInfo(depInfo); f != "" {
 		bom.Metadata.Properties = cdxutils.AppendProperties(bom.Metadata.Properties, cyclonedx.Property{
 			Name:  gitlabDependencyScanningInputFilePath,
-			Value: unique[0],
+			Value: f,
 		})
 	}
 
@@ -86,30 +86,24 @@ type depReachInfo struct {
 	inputFile string
 }
 
-func uniqueNonEmptyInputFilesFromDepInfo(depInfo map[string]*depReachInfo) []string {
+// uniqueInputFileFromDepInfo returns the single lock/manifest file shared by all assessed dependencies,
+// or empty if there are zero or more than one (multiple lockfiles: do not guess metadata-level path).
+func uniqueInputFileFromDepInfo(depInfo map[string]*depReachInfo) string {
 	seen := make(map[string]struct{})
 	for _, info := range depInfo {
 		if info == nil || info.rank <= reachNone {
 			continue
 		}
-		f := strings.TrimSpace(info.inputFile)
-		if f == "" {
-			continue
+		if f := strings.TrimSpace(info.inputFile); f != "" {
+			seen[f] = struct{}{}
 		}
-		seen[f] = struct{}{}
 	}
-	if len(seen) == 0 {
-		return nil
+	if len(seen) == 1 {
+		for f := range seen {
+			return f
+		}
 	}
-	out := make([]string, 0, len(seen))
-	for f := range seen {
-		out = append(out, f)
-	}
-	if len(out) == 1 {
-		return out
-	}
-	// Multiple lockfiles in one BOM: do not guess metadata-level path.
-	return nil
+	return ""
 }
 
 func mergeRowReachability(depInfo map[string]*depReachInfo, v *formats.VulnerabilityOrViolationRow) {
@@ -117,24 +111,24 @@ func mergeRowReachability(depInfo map[string]*depReachInfo, v *formats.Vulnerabi
 	if !ok {
 		return
 	}
+	name := strings.TrimSpace(v.ImpactedDependencyName)
+	if name == "" {
+		return
+	}
+	key := dependencyReachabilityKey(name, strings.TrimSpace(v.ImpactedDependencyVersion))
 	inFile := rowPreferredInputFile(v)
-	for _, key := range rowDependencyKeys(v) {
-		if key == "" {
-			continue
-		}
-		cur := depInfo[key]
-		if cur == nil {
-			cur = &depReachInfo{}
-			depInfo[key] = cur
-		}
-		if r > cur.rank {
-			cur.rank = r
-			if inFile != "" {
-				cur.inputFile = inFile
-			}
-		} else if r == cur.rank && cur.inputFile == "" && inFile != "" {
+	cur := depInfo[key]
+	if cur == nil {
+		cur = &depReachInfo{}
+		depInfo[key] = cur
+	}
+	if r > cur.rank {
+		cur.rank = r
+		if inFile != "" {
 			cur.inputFile = inFile
 		}
+	} else if r == cur.rank && cur.inputFile == "" && inFile != "" {
+		cur.inputFile = inFile
 	}
 }
 
@@ -152,15 +146,6 @@ func rowPreferredInputFile(v *formats.VulnerabilityOrViolationRow) string {
 		}
 	}
 	return strings.TrimSpace(manifestFileForTechnology(v.Technology))
-}
-
-func rowDependencyKeys(v *formats.VulnerabilityOrViolationRow) []string {
-	name := strings.TrimSpace(v.ImpactedDependencyName)
-	ver := strings.TrimSpace(v.ImpactedDependencyVersion)
-	if name == "" {
-		return nil
-	}
-	return []string{dependencyReachabilityKey(name, ver)}
 }
 
 func dependencyReachabilityKey(name, version string) string {

--- a/utils/gitlabreport/cyclonedx_gitlab_reachability.go
+++ b/utils/gitlabreport/cyclonedx_gitlab_reachability.go
@@ -34,11 +34,8 @@ const (
 )
 
 // EnrichCycloneDXBOMForGitLabReachability adds GitLab CycloneDX properties so the Security UI
-// "Reachable" field reflects JFrog contextual analysis (applicability): Applicable → in_use (Yes),
-// other assessed outcomes → not_found (Not Found), no applicability data → omit (Not Available).
-//
-// GitLab only merges SBOM reachability into findings when the BOM is uploaded as a CycloneDX
-// report (artifacts:reports:cyclonedx), not as a generic artifact path alone.
+// "Reachable" field reflects JFrog contextual analysis: Applicable → in_use, other assessed → not_found,
+// no applicability data → omitted (shows as "Not Available").
 func EnrichCycloneDXBOMForGitLabReachability(bom *cyclonedx.BOM, scanResults *results.SecurityCommandResults) {
 	if bom == nil || scanResults == nil {
 		return
@@ -84,7 +81,6 @@ func EnrichCycloneDXBOMForGitLabReachability(bom *cyclonedx.BOM, scanResults *re
 	walkComponentSlice(bom.Components, depInfo)
 }
 
-// depReachInfo holds merged reachability and a manifest path for GitLab SBOM correlation.
 type depReachInfo struct {
 	rank      reachRank
 	inputFile string
@@ -142,7 +138,6 @@ func mergeRowReachability(depInfo map[string]*depReachInfo, v *formats.Vulnerabi
 	}
 }
 
-// rowPreferredInputFile picks a repo-relative lock/manifest path for gitlab:dependency_scanning:input_file:path.
 func rowPreferredInputFile(v *formats.VulnerabilityOrViolationRow) string {
 	for _, comp := range v.Components {
 		if comp.PreferredLocation != nil {
@@ -172,7 +167,6 @@ func dependencyReachabilityKey(name, version string) string {
 	return name + "\x00" + version
 }
 
-// gitlabReachabilityRankForRow maps aggregated contextual analysis to GitLab reachability ranks.
 func gitlabReachabilityRankForRow(v *formats.VulnerabilityOrViolationRow) (reachRank, bool) {
 	switch rowFinalApplicabilityStatus(v) {
 	case jasutils.NotScanned:

--- a/utils/gitlabreport/cyclonedx_gitlab_reachability_test.go
+++ b/utils/gitlabreport/cyclonedx_gitlab_reachability_test.go
@@ -1,0 +1,60 @@
+package gitlabreport
+
+import (
+	"testing"
+
+	"github.com/CycloneDX/cyclonedx-go"
+	"github.com/jfrog/jfrog-cli-security/utils/formats"
+	"github.com/jfrog/jfrog-cli-security/utils/jasutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGitlabReachabilityRankForRow(t *testing.T) {
+	t.Run("not scanned omits property", func(t *testing.T) {
+		v := formats.VulnerabilityOrViolationRow{
+			ImpactedDependencyDetails: formats.ImpactedDependencyDetails{
+				ImpactedDependencyName: "lib", ImpactedDependencyVersion: "1.0.0",
+			},
+			Cves: []formats.CveRow{{Id: "CVE-2024-1"}},
+		}
+		r, ok := gitlabReachabilityRankForRow(&v)
+		assert.False(t, ok)
+		assert.Equal(t, reachNone, r)
+	})
+	t.Run("applicable is in_use", func(t *testing.T) {
+		v := formats.VulnerabilityOrViolationRow{
+			ImpactedDependencyDetails: formats.ImpactedDependencyDetails{
+				ImpactedDependencyName: "lib", ImpactedDependencyVersion: "1.0.0",
+			},
+			Cves: []formats.CveRow{{
+				Id:            "CVE-2024-1",
+				Applicability: &formats.Applicability{Status: jasutils.Applicable.String()},
+			}},
+		}
+		r, ok := gitlabReachabilityRankForRow(&v)
+		require.True(t, ok)
+		assert.Equal(t, reachInUse, r)
+	})
+	t.Run("not applicable is not_found", func(t *testing.T) {
+		v := formats.VulnerabilityOrViolationRow{
+			ImpactedDependencyDetails: formats.ImpactedDependencyDetails{
+				ImpactedDependencyName: "lib", ImpactedDependencyVersion: "1.0.0",
+			},
+			Cves: []formats.CveRow{{
+				Id:            "CVE-2024-1",
+				Applicability: &formats.Applicability{Status: jasutils.NotApplicable.String()},
+			}},
+		}
+		r, ok := gitlabReachabilityRankForRow(&v)
+		require.True(t, ok)
+		assert.Equal(t, reachNotFound, r)
+	})
+}
+
+func TestEnrichCycloneDXBOMForGitLabReachability_nilSafe(t *testing.T) {
+	EnrichCycloneDXBOMForGitLabReachability(nil, nil)
+	bom := &cyclonedx.BOM{}
+	EnrichCycloneDXBOMForGitLabReachability(bom, nil)
+	assert.Nil(t, bom.Metadata)
+}

--- a/utils/gitlabreport/cyclonedx_gitlab_reachability_test.go
+++ b/utils/gitlabreport/cyclonedx_gitlab_reachability_test.go
@@ -58,3 +58,54 @@ func TestEnrichCycloneDXBOMForGitLabReachability_nilSafe(t *testing.T) {
 	EnrichCycloneDXBOMForGitLabReachability(bom, nil)
 	assert.Nil(t, bom.Metadata)
 }
+
+func TestWalkComponentTree_setsGitLabPropertiesAndTrimsPurlQuery(t *testing.T) {
+	depInfo := map[string]*depReachInfo{
+		dependencyReachabilityKey("minimist", "1.2.5"): {
+			rank:      reachInUse,
+			inputFile: "node_modules/minimist/package.json",
+		},
+	}
+	c := &cyclonedx.Component{
+		Type:       cyclonedx.ComponentTypeLibrary,
+		Name:       "minimist",
+		Version:    "1.2.5",
+		PackageURL: "pkg:npm/minimist@1.2.5?foo=bar",
+	}
+
+	walkComponentTree(c, depInfo)
+
+	assert.Equal(t, "pkg:npm/minimist@1.2.5", c.PackageURL, "query params should be stripped for stable matching")
+	require.NotNil(t, c.Properties)
+	props := map[string]string{}
+	for _, p := range *c.Properties {
+		props[p.Name] = p.Value
+	}
+	assert.Equal(t, "node_modules/minimist/package.json", props[gitlabDependencyScanningInputFilePath])
+	assert.Equal(t, gitlabReachabilityInUse, props[gitlabDependencyScanningReachability])
+}
+
+func TestWalkComponentTree_usesGroupPrefixedNameMatch(t *testing.T) {
+	depInfo := map[string]*depReachInfo{
+		dependencyReachabilityKey("com.thoughtworks.xstream:xstream", "1.4.5"): {
+			rank:      reachNotFound,
+			inputFile: "pom.xml",
+		},
+	}
+	c := &cyclonedx.Component{
+		Type:    cyclonedx.ComponentTypeLibrary,
+		Group:   "com.thoughtworks.xstream",
+		Name:    "xstream",
+		Version: "1.4.5",
+	}
+
+	walkComponentTree(c, depInfo)
+
+	require.NotNil(t, c.Properties)
+	props := map[string]string{}
+	for _, p := range *c.Properties {
+		props[p.Name] = p.Value
+	}
+	assert.Equal(t, "pom.xml", props[gitlabDependencyScanningInputFilePath])
+	assert.Equal(t, gitlabReachabilityNotFound, props[gitlabDependencyScanningReachability])
+}

--- a/utils/gitlabreport/gitlabreport.go
+++ b/utils/gitlabreport/gitlabreport.go
@@ -242,7 +242,7 @@ func buildIdentifiers(v *formats.VulnerabilityOrViolationRow) []Identifier {
 		if cve.Id != "" {
 			ids = append(ids, Identifier{
 				Type:  "cve",
-				Name:  "CVE",
+				Name:  cve.Id,
 				Value: cve.Id,
 				URL:   "https://nvd.nist.gov/vuln/detail/" + cve.Id,
 			})
@@ -251,15 +251,25 @@ func buildIdentifiers(v *formats.VulnerabilityOrViolationRow) []Identifier {
 	if v.IssueId != "" && !strings.HasPrefix(strings.ToUpper(v.IssueId), "CVE-") {
 		ids = append(ids, Identifier{
 			Type:  "xray",
-			Name:  "Xray",
+			Name:  v.IssueId,
 			Value: v.IssueId,
 		})
 	}
 	if len(ids) == 0 {
+		issue := strings.TrimSpace(v.IssueId)
+		if issue != "" && strings.HasPrefix(strings.ToUpper(issue), "CVE-") {
+			return []Identifier{{
+				Type:  "cve",
+				Name:  issue,
+				Value: issue,
+				URL:   "https://nvd.nist.gov/vuln/detail/" + issue,
+			}}
+		}
+		fallback := v.ImpactedDependencyName + "@" + v.ImpactedDependencyVersion
 		ids = append(ids, Identifier{
 			Type:  "other",
-			Name:  "JFrog Xray",
-			Value: v.ImpactedDependencyName + "@" + v.ImpactedDependencyVersion,
+			Name:  fallback,
+			Value: fallback,
 		})
 	}
 	return ids

--- a/utils/gitlabreport/gitlabreport.go
+++ b/utils/gitlabreport/gitlabreport.go
@@ -56,15 +56,17 @@ type Vendor struct {
 }
 
 type VulnerabilityReport struct {
-	ID          string                         `json:"id"`
-	Name        string                         `json:"name,omitempty"`
-	Description string                         `json:"description,omitempty"`
-	Severity    string                         `json:"severity,omitempty"` // Info, Unknown, Low, Medium, High, Critical
-	Solution    string                         `json:"solution,omitempty"`
-	Identifiers []Identifier                   `json:"identifiers"`
-	Location    Location                       `json:"location"`
-	Links       []Link                         `json:"links,omitempty"`
-	Details     map[string]DetailNamedListItem `json:"details,omitempty"` // named-list *items* only; see schema note on buildReachabilityDetails
+	ID          string       `json:"id"`
+	Name        string       `json:"name,omitempty"`
+	Description string       `json:"description,omitempty"`
+	Severity    string       `json:"severity,omitempty"` // Info, Unknown, Low, Medium, High, Critical
+	Solution    string       `json:"solution,omitempty"`
+	Identifiers []Identifier `json:"identifiers"`
+	Location    Location     `json:"location"`
+	Links       []Link       `json:"links,omitempty"`
+	// Details is optional per GitLab schema (named-list item map). Reachable is set on CycloneDX
+	// components (gitlab:dependency_scanning_component:reachability), not here.
+	Details map[string]DetailNamedListItem `json:"details,omitempty"`
 }
 
 // DetailNamedListItem merges named_field (name) with a detail payload (e.g. type "text" + value).
@@ -206,11 +208,6 @@ func vulnerabilityToReport(v *formats.VulnerabilityOrViolationRow) Vulnerability
 	// contextual analysis in name so it appears in the list; description holds summary only.
 	name := buildVulnerabilityNameWithContextualAnalysis(v)
 	desc := strings.TrimSpace(getSummary(v))
-	reach := contextualAnalysisReachabilityText(v)
-	var details map[string]DetailNamedListItem
-	if strings.TrimSpace(reach) != "" {
-		details = buildReachabilityDetails(reach)
-	}
 	solution := ""
 	if len(v.FixedVersions) > 0 {
 		solution = fmt.Sprintf("Upgrade %s to version %s or later.", v.ImpactedDependencyName, v.FixedVersions[0])
@@ -230,7 +227,6 @@ func vulnerabilityToReport(v *formats.VulnerabilityOrViolationRow) Vulnerability
 		Identifiers: identifiers,
 		Location:    location,
 		Links:       links,
-		Details:     details,
 	}
 }
 
@@ -409,52 +405,6 @@ func aggregatedContextualAnalysisDisplay(v *formats.VulnerabilityOrViolationRow)
 		return jasutils.NotCovered.String()
 	}
 	return st.String()
-}
-
-// contextualAnalysisReachabilityText returns contextual analysis (JAS applicability) for the
-// Reachable detail field: per-CVE lines when available, otherwise the row-level status when the
-// finding has a titled vulnerability.
-func contextualAnalysisReachabilityText(v *formats.VulnerabilityOrViolationRow) string {
-	if s := contextualAnalysisDescriptionPrefix(v); strings.TrimSpace(s) != "" {
-		return strings.TrimSpace(s)
-	}
-	if buildVulnerabilityNameWithContextualAnalysis(v) == "" {
-		return ""
-	}
-	return aggregatedContextualAnalysisDisplay(v)
-}
-
-func buildReachabilityDetails(reachabilityText string) map[string]DetailNamedListItem {
-	return map[string]DetailNamedListItem{
-		"reachable": {
-			Name:  "Reachable",
-			Type:  "text",
-			Value: reachabilityText,
-		},
-	}
-}
-
-// contextualAnalysisDescriptionPrefix builds "CVE-2024-1 (Applicable). CVE-2024-2 (Not Applicable)." per CVE row.
-// When a CVE has no applicability assessment, status is "Not Covered".
-func contextualAnalysisDescriptionPrefix(v *formats.VulnerabilityOrViolationRow) string {
-	var b strings.Builder
-	for _, cve := range v.Cves {
-		if cve.Id == "" {
-			continue
-		}
-		status := jasutils.NotCovered.String()
-		if cve.Applicability != nil && cve.Applicability.Status != "" {
-			status = cve.Applicability.Status
-		}
-		if b.Len() > 0 {
-			b.WriteString(" ")
-		}
-		b.WriteString(cve.Id)
-		b.WriteString(" (")
-		b.WriteString(status)
-		b.WriteString(").")
-	}
-	return b.String()
 }
 
 func sortVulnerabilityRowsForGitLab(vulns []formats.VulnerabilityOrViolationRow) {

--- a/utils/gitlabreport/gitlabreport.go
+++ b/utils/gitlabreport/gitlabreport.go
@@ -278,21 +278,98 @@ func buildIdentifiers(v *formats.VulnerabilityOrViolationRow) []Identifier {
 	if len(ids) == 0 {
 		issue := strings.TrimSpace(v.IssueId)
 		if issue != "" && strings.HasPrefix(strings.ToUpper(issue), "CVE-") {
-			return []Identifier{{
+			ids = append(ids, Identifier{
 				Type:  "cve",
 				Name:  issue,
 				Value: issue,
 				URL:   "https://nvd.nist.gov/vuln/detail/" + issue,
-			}}
+			})
+		} else {
+			fallback := v.ImpactedDependencyName + "@" + v.ImpactedDependencyVersion
+			ids = append(ids, Identifier{
+				Type:  "other",
+				Name:  fallback,
+				Value: fallback,
+			})
 		}
-		fallback := v.ImpactedDependencyName + "@" + v.ImpactedDependencyVersion
-		ids = append(ids, Identifier{
-			Type:  "other",
-			Name:  fallback,
-			Value: fallback,
-		})
+	}
+	return appendUniqueCWEIdentifiers(ids, v)
+}
+
+// appendUniqueCWEIdentifiers adds GitLab dependency-scanning identifiers with type "cwe" from each
+// CVE row's Cwe list (Xray simple JSON). GitLab aggregates these for dashboards such as "Top 10 CWEs".
+func appendUniqueCWEIdentifiers(ids []Identifier, v *formats.VulnerabilityOrViolationRow) []Identifier {
+	seen := make(map[string]struct{})
+	for _, id := range ids {
+		if id.Type == "cwe" {
+			seen[strings.ToUpper(id.Value)] = struct{}{}
+		}
+	}
+	for _, cve := range v.Cves {
+		for _, raw := range cve.Cwe {
+			canon := normalizeCweID(raw)
+			if canon == "" {
+				continue
+			}
+			key := strings.ToUpper(canon)
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			id := Identifier{
+				Type:  "cwe",
+				Name:  canon,
+				Value: canon,
+			}
+			if u := cweMitreDefinitionsURL(canon); u != "" {
+				id.URL = u
+			}
+			ids = append(ids, id)
+		}
 	}
 	return ids
+}
+
+func normalizeCweID(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	u := strings.ToUpper(raw)
+	if strings.HasPrefix(u, "CWE-") {
+		n := strings.TrimPrefix(u, "CWE-")
+		n = strings.TrimSpace(n)
+		if cweNumericID(n) != "" {
+			return "CWE-" + cweNumericID(n)
+		}
+		return ""
+	}
+	if cweNumericID(u) != "" {
+		return "CWE-" + cweNumericID(u)
+	}
+	return ""
+}
+
+// cweNumericID returns digits-only CWE id, or empty if invalid.
+func cweNumericID(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return ""
+		}
+	}
+	return s
+}
+
+func cweMitreDefinitionsURL(cweCanon string) string {
+	n := cweNumericID(strings.TrimPrefix(strings.ToUpper(strings.TrimSpace(cweCanon)), "CWE-"))
+	if n == "" {
+		return ""
+	}
+	return "https://cwe.mitre.org/data/definitions/" + n + ".html"
 }
 
 func getSeverity(v *formats.VulnerabilityOrViolationRow) string {

--- a/utils/gitlabreport/gitlabreport.go
+++ b/utils/gitlabreport/gitlabreport.go
@@ -56,14 +56,28 @@ type Vendor struct {
 }
 
 type VulnerabilityReport struct {
-	ID          string       `json:"id"`
-	Name        string       `json:"name,omitempty"`
-	Description string       `json:"description,omitempty"`
-	Severity    string       `json:"severity,omitempty"` // Info, Unknown, Low, Medium, High, Critical
-	Solution    string       `json:"solution,omitempty"`
-	Identifiers []Identifier `json:"identifiers"`
-	Location    Location     `json:"location"`
-	Links       []Link       `json:"links,omitempty"`
+	ID          string            `json:"id"`
+	Name        string            `json:"name,omitempty"`
+	Description string            `json:"description,omitempty"`
+	Severity    string            `json:"severity,omitempty"` // Info, Unknown, Low, Medium, High, Critical
+	Solution    string            `json:"solution,omitempty"`
+	Identifiers []Identifier      `json:"identifiers"`
+	Location    Location          `json:"location"`
+	Links       []Link            `json:"links,omitempty"`
+	Details     *DetailsNamedList `json:"details,omitempty"` // e.g. Reachable (contextual analysis); see dependency-scanning schema `details`
+}
+
+// DetailsNamedList is GitLab's named-list detail block (security report schema).
+type DetailsNamedList struct {
+	Type  string                         `json:"type"` // must be "named-list"
+	Items map[string]DetailNamedListItem `json:"items"`
+}
+
+// DetailNamedListItem merges named_field (name) with a detail payload (e.g. type "text" + value).
+type DetailNamedListItem struct {
+	Name  string `json:"name"`
+	Type  string `json:"type"` // "text"
+	Value string `json:"value"`
 }
 
 type Identifier struct {
@@ -192,9 +206,14 @@ func vulnerabilityToReport(v *formats.VulnerabilityOrViolationRow) Vulnerability
 	severity := normalizeSeverity(getSeverity(v))
 	// GitLab's vulnerability list "Description" column is built from the finding title (name) and
 	// manifest path — it does not show the JSON description body in that column. Include
-	// contextual analysis in name so it appears in the list; description still holds full text.
+	// contextual analysis in name so it appears in the list; description holds summary only.
 	name := buildVulnerabilityNameWithContextualAnalysis(v)
-	desc := buildGitLabDescription(v)
+	desc := strings.TrimSpace(getSummary(v))
+	reach := contextualAnalysisReachabilityText(v)
+	var details *DetailsNamedList
+	if strings.TrimSpace(reach) != "" {
+		details = buildReachabilityNamedList(reach)
+	}
 	solution := ""
 	if len(v.FixedVersions) > 0 {
 		solution = fmt.Sprintf("Upgrade %s to version %s or later.", v.ImpactedDependencyName, v.FixedVersions[0])
@@ -214,6 +233,7 @@ func vulnerabilityToReport(v *formats.VulnerabilityOrViolationRow) Vulnerability
 		Identifiers: identifiers,
 		Location:    location,
 		Links:       links,
+		Details:     details,
 	}
 }
 
@@ -317,18 +337,29 @@ func aggregatedContextualAnalysisDisplay(v *formats.VulnerabilityOrViolationRow)
 	return st.String()
 }
 
-// buildGitLabDescription prepends contextual analysis lines in the form "CVE-ID (status)." for each CVE,
-// then the vulnerability summary (when present).
-func buildGitLabDescription(v *formats.VulnerabilityOrViolationRow) string {
-	prefix := contextualAnalysisDescriptionPrefix(v)
-	summary := getSummary(v)
-	switch {
-	case prefix != "" && summary != "":
-		return prefix + "\n\n" + summary
-	case prefix != "":
-		return prefix
-	default:
-		return summary
+// contextualAnalysisReachabilityText returns contextual analysis (JAS applicability) for the
+// Reachable detail field: per-CVE lines when available, otherwise the row-level status when the
+// finding has a titled vulnerability.
+func contextualAnalysisReachabilityText(v *formats.VulnerabilityOrViolationRow) string {
+	if s := contextualAnalysisDescriptionPrefix(v); strings.TrimSpace(s) != "" {
+		return strings.TrimSpace(s)
+	}
+	if buildVulnerabilityNameWithContextualAnalysis(v) == "" {
+		return ""
+	}
+	return aggregatedContextualAnalysisDisplay(v)
+}
+
+func buildReachabilityNamedList(reachabilityText string) *DetailsNamedList {
+	return &DetailsNamedList{
+		Type: "named-list",
+		Items: map[string]DetailNamedListItem{
+			"reachable": {
+				Name:  "Reachable",
+				Type:  "text",
+				Value: reachabilityText,
+			},
+		},
 	}
 }
 

--- a/utils/gitlabreport/gitlabreport.go
+++ b/utils/gitlabreport/gitlabreport.go
@@ -56,21 +56,15 @@ type Vendor struct {
 }
 
 type VulnerabilityReport struct {
-	ID          string            `json:"id"`
-	Name        string            `json:"name,omitempty"`
-	Description string            `json:"description,omitempty"`
-	Severity    string            `json:"severity,omitempty"` // Info, Unknown, Low, Medium, High, Critical
-	Solution    string            `json:"solution,omitempty"`
-	Identifiers []Identifier      `json:"identifiers"`
-	Location    Location          `json:"location"`
-	Links       []Link            `json:"links,omitempty"`
-	Details     *DetailsNamedList `json:"details,omitempty"` // e.g. Reachable (contextual analysis); see dependency-scanning schema `details`
-}
-
-// DetailsNamedList is GitLab's named-list detail block (security report schema).
-type DetailsNamedList struct {
-	Type  string                         `json:"type"` // must be "named-list"
-	Items map[string]DetailNamedListItem `json:"items"`
+	ID          string                         `json:"id"`
+	Name        string                         `json:"name,omitempty"`
+	Description string                         `json:"description,omitempty"`
+	Severity    string                         `json:"severity,omitempty"` // Info, Unknown, Low, Medium, High, Critical
+	Solution    string                         `json:"solution,omitempty"`
+	Identifiers []Identifier                   `json:"identifiers"`
+	Location    Location                       `json:"location"`
+	Links       []Link                         `json:"links,omitempty"`
+	Details     map[string]DetailNamedListItem `json:"details,omitempty"` // named-list *items* only; see schema note on buildReachabilityDetails
 }
 
 // DetailNamedListItem merges named_field (name) with a detail payload (e.g. type "text" + value).
@@ -124,8 +118,11 @@ func ConvertToGitLabDependencyScanningReport(scanResults *results.SecurityComman
 		}, nil
 	}
 
+	// Always include SCA vulnerabilities in this export. scanResults.IncludesVulnerabilities()
+	// reflects the interactive scan context (e.g. violation-only views); when false, jfrog-cli-security
+	// skips ParseCVEs and the GitLab JSON would be empty even with many SBOM CVEs — wrong for CI reports.
 	convertor := conversion.NewCommandResultsConvertor(conversion.ResultConvertParams{
-		IncludeVulnerabilities: scanResults.IncludesVulnerabilities(),
+		IncludeVulnerabilities: true,
 		HasViolationContext:    scanResults.HasViolationContext(),
 	})
 	simpleJSON, err := convertor.ConvertToSimpleJson(scanResults)
@@ -210,9 +207,9 @@ func vulnerabilityToReport(v *formats.VulnerabilityOrViolationRow) Vulnerability
 	name := buildVulnerabilityNameWithContextualAnalysis(v)
 	desc := strings.TrimSpace(getSummary(v))
 	reach := contextualAnalysisReachabilityText(v)
-	var details *DetailsNamedList
+	var details map[string]DetailNamedListItem
 	if strings.TrimSpace(reach) != "" {
-		details = buildReachabilityNamedList(reach)
+		details = buildReachabilityDetails(reach)
 	}
 	solution := ""
 	if len(v.FixedVersions) > 0 {
@@ -427,15 +424,12 @@ func contextualAnalysisReachabilityText(v *formats.VulnerabilityOrViolationRow) 
 	return aggregatedContextualAnalysisDisplay(v)
 }
 
-func buildReachabilityNamedList(reachabilityText string) *DetailsNamedList {
-	return &DetailsNamedList{
-		Type: "named-list",
-		Items: map[string]DetailNamedListItem{
-			"reachable": {
-				Name:  "Reachable",
-				Type:  "text",
-				Value: reachabilityText,
-			},
+func buildReachabilityDetails(reachabilityText string) map[string]DetailNamedListItem {
+	return map[string]DetailNamedListItem{
+		"reachable": {
+			Name:  "Reachable",
+			Type:  "text",
+			Value: reachabilityText,
 		},
 	}
 }

--- a/utils/gitlabreport/gitlabreport.go
+++ b/utils/gitlabreport/gitlabreport.go
@@ -1,0 +1,334 @@
+package gitlabreport
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/jfrog/jfrog-cli-security/utils/formats"
+	"github.com/jfrog/jfrog-cli-security/utils/results"
+	"github.com/jfrog/jfrog-cli-security/utils/results/conversion"
+	"github.com/jfrog/jfrog-cli-security/utils/techutils"
+	"github.com/jfrog/jfrog-client-go/utils/log"
+)
+
+const (
+	gitLabReportSchemaVersion = "15.2.4"
+	gitLabReportSchemaURL     = "https://gitlab.com/gitlab-org/security-products/security-report-schemas/-/raw/master/dist/dependency-scanning-report-format.json"
+	frogbotAnalyzerID         = "frogbot-dependency-scanning"
+	frogbotAnalyzerName       = "JFrog Frogbot"
+	frogbotVendorName         = "JFrog"
+)
+
+type DependencyScanningReport struct {
+	Scan            ScanReport            `json:"scan"`
+	Schema          string                `json:"schema,omitempty"`
+	Version         string                `json:"version"`
+	Vulnerabilities []VulnerabilityReport `json:"vulnerabilities"`
+}
+
+type ScanReport struct {
+	Analyzer  AnalyzerScanner `json:"analyzer"`
+	Scanner   AnalyzerScanner `json:"scanner"`
+	StartTime string          `json:"start_time"` // ISO8601 UTC yyyy-mm-ddThh:mm:ss
+	EndTime   string          `json:"end_time"`
+	Status    string          `json:"status"` // "success" or "failure"
+	Type      string          `json:"type"`   // "dependency_scanning"
+}
+
+type AnalyzerScanner struct {
+	ID      string `json:"id"`
+	Name    string `json:"name"`
+	Version string `json:"version"`
+	Vendor  Vendor `json:"vendor"`
+	URL     string `json:"url,omitempty"`
+}
+
+type Vendor struct {
+	Name string `json:"name"`
+}
+
+type VulnerabilityReport struct {
+	ID          string       `json:"id"`
+	Name        string       `json:"name,omitempty"`
+	Description string       `json:"description,omitempty"`
+	Severity    string       `json:"severity,omitempty"` // Info, Unknown, Low, Medium, High, Critical
+	Solution    string       `json:"solution,omitempty"`
+	Identifiers []Identifier `json:"identifiers"`
+	Location    Location     `json:"location"`
+	Links       []Link       `json:"links,omitempty"`
+}
+
+type Identifier struct {
+	Type  string `json:"type"`
+	Name  string `json:"name"`
+	Value string `json:"value"`
+	URL   string `json:"url,omitempty"`
+}
+
+type Location struct {
+	File       string     `json:"file"`
+	Dependency Dependency `json:"dependency"`
+}
+
+type Dependency struct {
+	Package Package `json:"package"`
+	Version string  `json:"version"`
+	Direct  *bool   `json:"direct,omitempty"`
+}
+
+type Package struct {
+	Name string `json:"name"`
+}
+
+type Link struct {
+	Name string `json:"name,omitempty"`
+	URL  string `json:"url"`
+}
+
+func ConvertToGitLabDependencyScanningReport(scanResults *results.SecurityCommandResults, startTime, endTime time.Time, frogbotVersion string) (*DependencyScanningReport, error) {
+	if scanResults == nil {
+		return &DependencyScanningReport{
+			Scan: ScanReport{
+				Analyzer:  makeAnalyzerScanner(frogbotVersion),
+				Scanner:   makeAnalyzerScanner(frogbotVersion),
+				StartTime: formatGitLabTime(startTime),
+				EndTime:   formatGitLabTime(endTime),
+				Status:    "success",
+				Type:      "dependency_scanning",
+			},
+			Version:         gitLabReportSchemaVersion,
+			Schema:          gitLabReportSchemaURL,
+			Vulnerabilities: []VulnerabilityReport{},
+		}, nil
+	}
+
+	convertor := conversion.NewCommandResultsConvertor(conversion.ResultConvertParams{
+		IncludeVulnerabilities: scanResults.IncludesVulnerabilities(),
+		HasViolationContext:    scanResults.HasViolationContext(),
+	})
+	simpleJSON, err := convertor.ConvertToSimpleJson(scanResults)
+	if err != nil {
+		return nil, fmt.Errorf("convert to simple json: %w", err)
+	}
+
+	var vulns []formats.VulnerabilityOrViolationRow
+	vulns = append(vulns, simpleJSON.Vulnerabilities...)
+	vulns = append(vulns, simpleJSON.SecurityViolations...)
+
+	reports := make([]VulnerabilityReport, 0, len(vulns))
+	seen := make(map[string]struct{})
+
+	for i := range vulns {
+		v := &vulns[i]
+		key := v.ImpactedDependencyName + "|" + v.ImpactedDependencyVersion + "|" + v.IssueId
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+
+		report := vulnerabilityToReport(v)
+		reports = append(reports, report)
+	}
+
+	status := "success"
+	if err = scanResults.GetErrors(); err != nil {
+		status = "failure"
+	}
+
+	return &DependencyScanningReport{
+		Scan: ScanReport{
+			Analyzer:  makeAnalyzerScanner(frogbotVersion),
+			Scanner:   makeAnalyzerScanner(frogbotVersion),
+			StartTime: formatGitLabTime(startTime),
+			EndTime:   formatGitLabTime(endTime),
+			Status:    status,
+			Type:      "dependency_scanning",
+		},
+		Schema:          gitLabReportSchemaURL,
+		Version:         gitLabReportSchemaVersion,
+		Vulnerabilities: reports,
+	}, nil
+}
+
+func makeAnalyzerScanner(version string) AnalyzerScanner {
+	if version == "" {
+		version = "0.0.0"
+	}
+	return AnalyzerScanner{
+		ID:      frogbotAnalyzerID,
+		Name:    frogbotAnalyzerName,
+		Version: version,
+		Vendor:  Vendor{Name: frogbotVendorName},
+		URL:     "https://github.com/jfrog/frogbot",
+	}
+}
+
+func formatGitLabTime(t time.Time) string {
+	return t.UTC().Format("2006-01-02T15:04:05")
+}
+
+func vulnerabilityToReport(v *formats.VulnerabilityOrViolationRow) VulnerabilityReport {
+	id := deterministicVulnID(v.ImpactedDependencyName, v.ImpactedDependencyVersion, v.IssueId, v.Cves)
+	identifiers := buildIdentifiers(v)
+	location := Location{
+		File: manifestFileForTechnology(v.Technology),
+		Dependency: Dependency{
+			Package: Package{Name: v.ImpactedDependencyName},
+			Version: v.ImpactedDependencyVersion,
+		},
+	}
+	severity := normalizeSeverity(getSeverity(v))
+	name := v.IssueId
+	if len(v.Cves) > 0 {
+		name = v.Cves[0].Id
+	}
+	desc := getSummary(v)
+	solution := ""
+	if len(v.FixedVersions) > 0 {
+		solution = fmt.Sprintf("Upgrade %s to version %s or later.", v.ImpactedDependencyName, v.FixedVersions[0])
+	}
+	var links []Link
+	for _, cve := range v.Cves {
+		if cve.Id != "" {
+			links = append(links, Link{Name: cve.Id, URL: "https://nvd.nist.gov/vuln/detail/" + cve.Id})
+		}
+	}
+	return VulnerabilityReport{
+		ID:          id,
+		Name:        name,
+		Description: desc,
+		Severity:    severity,
+		Solution:    solution,
+		Identifiers: identifiers,
+		Location:    location,
+		Links:       links,
+	}
+}
+
+func deterministicVulnID(pkg, version, issueId string, cves []formats.CveRow) string {
+	h := sha256.New()
+	h.Write([]byte(pkg))
+	h.Write([]byte("|"))
+	h.Write([]byte(version))
+	h.Write([]byte("|"))
+	h.Write([]byte(issueId))
+	for _, c := range cves {
+		h.Write([]byte(c.Id))
+	}
+	sum := h.Sum(nil)
+	hexStr := hex.EncodeToString(sum)
+	// Format as UUID-like 8-4-4-4-12 for compatibility
+	if len(hexStr) < 32 {
+		hexStr = hexStr + strings.Repeat("0", 32-len(hexStr))
+	}
+	return hexStr[0:8] + "-" + hexStr[8:12] + "-" + hexStr[12:16] + "-" + hexStr[16:20] + "-" + hexStr[20:32]
+}
+
+func buildIdentifiers(v *formats.VulnerabilityOrViolationRow) []Identifier {
+	var ids []Identifier
+	for _, cve := range v.Cves {
+		if cve.Id != "" {
+			ids = append(ids, Identifier{
+				Type:  "cve",
+				Name:  "CVE",
+				Value: cve.Id,
+				URL:   "https://nvd.nist.gov/vuln/detail/" + cve.Id,
+			})
+		}
+	}
+	if v.IssueId != "" && !strings.HasPrefix(strings.ToUpper(v.IssueId), "CVE-") {
+		ids = append(ids, Identifier{
+			Type:  "xray",
+			Name:  "Xray",
+			Value: v.IssueId,
+		})
+	}
+	if len(ids) == 0 {
+		ids = append(ids, Identifier{
+			Type:  "other",
+			Name:  "JFrog Xray",
+			Value: v.ImpactedDependencyName + "@" + v.ImpactedDependencyVersion,
+		})
+	}
+	return ids
+}
+
+func getSeverity(v *formats.VulnerabilityOrViolationRow) string {
+	if v.Severity != "" {
+		return v.Severity
+	}
+	if v.ImpactedDependencyDetails.SeverityDetails.Severity != "" {
+		return v.ImpactedDependencyDetails.SeverityDetails.Severity
+	}
+	return ""
+}
+
+func getSummary(v *formats.VulnerabilityOrViolationRow) string {
+	if v.Summary != "" {
+		return v.Summary
+	}
+	if v.JfrogResearchInformation != nil && v.JfrogResearchInformation.Summary != "" {
+		return v.JfrogResearchInformation.Summary
+	}
+	return ""
+}
+
+func normalizeSeverity(severity string) string {
+	switch strings.ToLower(severity) {
+	case "critical":
+		return "Critical"
+	case "high":
+		return "High"
+	case "medium", "moderate":
+		return "Medium"
+	case "low":
+		return "Low"
+	case "info", "informational":
+		return "Info"
+	default:
+		return "Unknown"
+	}
+}
+
+func manifestFileForTechnology(tech techutils.Technology) string {
+	switch tech {
+	case techutils.Npm, techutils.Yarn:
+		return "package-lock.json"
+	case techutils.Go:
+		return "go.sum"
+	case techutils.Pip, techutils.Pipenv:
+		return "requirements.txt"
+	case techutils.Maven:
+		return "pom.xml"
+	case techutils.Nuget:
+		return "packages.config"
+	default:
+		return "manifest"
+	}
+}
+
+// WriteDependencyScanningReport writes the GitLab dependency-scanning report to outputDir/gl-dependency-scanning-report.json.
+func WriteDependencyScanningReport(outputDir string, report *DependencyScanningReport) error {
+	if outputDir == "" {
+		return fmt.Errorf("output directory is required")
+	}
+	if err := os.MkdirAll(outputDir, 0755); err != nil {
+		return fmt.Errorf("create output dir: %w", err)
+	}
+	path := filepath.Join(outputDir, "gl-dependency-scanning-report.json")
+	data, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal report: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		return fmt.Errorf("write report: %w", err)
+	}
+	log.Info(fmt.Sprintf("GitLab dependency-scanning report written to %s", path))
+	return nil
+}

--- a/utils/gitlabreport/gitlabreport.go
+++ b/utils/gitlabreport/gitlabreport.go
@@ -225,7 +225,7 @@ func deterministicVulnID(pkg, version, issueId string, cves []formats.CveRow) st
 	hexStr := hex.EncodeToString(sum)
 	// Format as UUID-like 8-4-4-4-12 for compatibility
 	if len(hexStr) < 32 {
-		hexStr = hexStr + strings.Repeat("0", 32-len(hexStr))
+		hexStr += strings.Repeat("0", 32-len(hexStr))
 	}
 	return hexStr[0:8] + "-" + hexStr[8:12] + "-" + hexStr[12:16] + "-" + hexStr[16:20] + "-" + hexStr[20:32]
 }

--- a/utils/gitlabreport/gitlabreport.go
+++ b/utils/gitlabreport/gitlabreport.go
@@ -7,10 +7,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
 	"github.com/jfrog/jfrog-cli-security/utils/formats"
+	"github.com/jfrog/jfrog-cli-security/utils/jasutils"
 	"github.com/jfrog/jfrog-cli-security/utils/results"
 	"github.com/jfrog/jfrog-cli-security/utils/results/conversion"
 	"github.com/jfrog/jfrog-cli-security/utils/techutils"
@@ -121,18 +123,22 @@ func ConvertToGitLabDependencyScanningReport(scanResults *results.SecurityComman
 	vulns = append(vulns, simpleJSON.Vulnerabilities...)
 	vulns = append(vulns, simpleJSON.SecurityViolations...)
 
-	reports := make([]VulnerabilityReport, 0, len(vulns))
+	unique := make([]formats.VulnerabilityOrViolationRow, 0, len(vulns))
 	seen := make(map[string]struct{})
-
 	for i := range vulns {
-		v := &vulns[i]
+		v := vulns[i]
 		key := v.ImpactedDependencyName + "|" + v.ImpactedDependencyVersion + "|" + v.IssueId
 		if _, ok := seen[key]; ok {
 			continue
 		}
 		seen[key] = struct{}{}
+		unique = append(unique, v)
+	}
+	sortVulnerabilityRowsForGitLab(unique)
 
-		report := vulnerabilityToReport(v)
+	reports := make([]VulnerabilityReport, 0, len(unique))
+	for i := range unique {
+		report := vulnerabilityToReport(&unique[i])
 		reports = append(reports, report)
 	}
 
@@ -184,11 +190,11 @@ func vulnerabilityToReport(v *formats.VulnerabilityOrViolationRow) Vulnerability
 		},
 	}
 	severity := normalizeSeverity(getSeverity(v))
-	name := v.IssueId
-	if len(v.Cves) > 0 {
-		name = v.Cves[0].Id
-	}
-	desc := getSummary(v)
+	// GitLab's vulnerability list "Description" column is built from the finding title (name) and
+	// manifest path — it does not show the JSON description body in that column. Include
+	// contextual analysis in name so it appears in the list; description still holds full text.
+	name := buildVulnerabilityNameWithContextualAnalysis(v)
+	desc := buildGitLabDescription(v)
 	solution := ""
 	if len(v.FixedVersions) > 0 {
 		solution = fmt.Sprintf("Upgrade %s to version %s or later.", v.ImpactedDependencyName, v.FixedVersions[0])
@@ -277,6 +283,131 @@ func getSummary(v *formats.VulnerabilityOrViolationRow) string {
 		return v.JfrogResearchInformation.Summary
 	}
 	return ""
+}
+
+// buildVulnerabilityNameWithContextualAnalysis sets the GitLab finding title to "CVE-ID (status)" using
+// aggregated contextual analysis for the row (same aggregation as Frogbot PR comments).
+func buildVulnerabilityNameWithContextualAnalysis(v *formats.VulnerabilityOrViolationRow) string {
+	base := v.IssueId
+	if len(v.Cves) > 0 && v.Cves[0].Id != "" {
+		base = v.Cves[0].Id
+	}
+	if base == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s (%s)", base, aggregatedContextualAnalysisDisplay(v))
+}
+
+// aggregatedContextualAnalysisDisplay returns a human-readable status; NotScanned maps to "Not Covered".
+func aggregatedContextualAnalysisDisplay(v *formats.VulnerabilityOrViolationRow) string {
+	st := rowFinalApplicabilityStatus(v)
+	if st == jasutils.NotScanned || st.String() == "" {
+		return jasutils.NotCovered.String()
+	}
+	return st.String()
+}
+
+// buildGitLabDescription prepends contextual analysis lines in the form "CVE-ID (status)." for each CVE,
+// then the vulnerability summary (when present).
+func buildGitLabDescription(v *formats.VulnerabilityOrViolationRow) string {
+	prefix := contextualAnalysisDescriptionPrefix(v)
+	summary := getSummary(v)
+	switch {
+	case prefix != "" && summary != "":
+		return prefix + "\n\n" + summary
+	case prefix != "":
+		return prefix
+	default:
+		return summary
+	}
+}
+
+// contextualAnalysisDescriptionPrefix builds "CVE-2024-1 (Applicable). CVE-2024-2 (Not Applicable)." per CVE row.
+// When a CVE has no applicability assessment, status is "Not Covered".
+func contextualAnalysisDescriptionPrefix(v *formats.VulnerabilityOrViolationRow) string {
+	var b strings.Builder
+	for _, cve := range v.Cves {
+		if cve.Id == "" {
+			continue
+		}
+		status := jasutils.NotCovered.String()
+		if cve.Applicability != nil && cve.Applicability.Status != "" {
+			status = cve.Applicability.Status
+		}
+		if b.Len() > 0 {
+			b.WriteString(" ")
+		}
+		b.WriteString(cve.Id)
+		b.WriteString(" (")
+		b.WriteString(status)
+		b.WriteString(").")
+	}
+	return b.String()
+}
+
+func sortVulnerabilityRowsForGitLab(vulns []formats.VulnerabilityOrViolationRow) {
+	sort.SliceStable(vulns, func(i, j int) bool {
+		si := normalizeSeverity(getSeverity(&vulns[i]))
+		sj := normalizeSeverity(getSeverity(&vulns[j]))
+		ri, rj := severitySortRank(si), severitySortRank(sj)
+		if ri != rj {
+			return ri < rj
+		}
+		ai := applicabilitySortRank(rowFinalApplicabilityStatus(&vulns[i]))
+		aj := applicabilitySortRank(rowFinalApplicabilityStatus(&vulns[j]))
+		if ai != aj {
+			return ai < aj
+		}
+		return vulns[i].IssueId < vulns[j].IssueId
+	})
+}
+
+func severitySortRank(normalized string) int {
+	switch normalized {
+	case "Critical":
+		return 0
+	case "High":
+		return 1
+	case "Medium":
+		return 2
+	case "Low":
+		return 3
+	case "Info":
+		return 4
+	default:
+		return 5 // Unknown
+	}
+}
+
+// rowFinalApplicabilityStatus aggregates per-CVE applicability like Frogbot PR comments.
+func rowFinalApplicabilityStatus(v *formats.VulnerabilityOrViolationRow) jasutils.ApplicabilityStatus {
+	var statuses []jasutils.ApplicabilityStatus
+	for _, cve := range v.Cves {
+		if cve.Applicability != nil && cve.Applicability.Status != "" {
+			statuses = append(statuses, jasutils.ConvertToApplicabilityStatus(cve.Applicability.Status))
+		}
+	}
+	return results.GetFinalApplicabilityStatus(len(statuses) > 0, statuses)
+}
+
+// applicabilitySortRank orders rows within the same severity: Applicable first, Not Applicable last.
+func applicabilitySortRank(status jasutils.ApplicabilityStatus) int {
+	switch status {
+	case jasutils.Applicable:
+		return 0
+	case jasutils.ApplicabilityUndetermined:
+		return 1
+	case jasutils.MissingContext:
+		return 2
+	case jasutils.NotCovered:
+		return 3
+	case jasutils.NotScanned:
+		return 4
+	case jasutils.NotApplicable:
+		return 5
+	default:
+		return 6
+	}
 }
 
 func normalizeSeverity(severity string) string {

--- a/utils/gitlabreport/gitlabreport.go
+++ b/utils/gitlabreport/gitlabreport.go
@@ -195,8 +195,12 @@ func formatGitLabTime(t time.Time) string {
 func vulnerabilityToReport(v *formats.VulnerabilityOrViolationRow) VulnerabilityReport {
 	id := deterministicVulnID(v.ImpactedDependencyName, v.ImpactedDependencyVersion, v.IssueId, v.Cves)
 	identifiers := buildIdentifiers(v)
+	manifestPath := rowPreferredInputFile(v)
+	if manifestPath == "" {
+		manifestPath = manifestFileForTechnology(v.Technology)
+	}
 	location := Location{
-		File: manifestFileForTechnology(v.Technology),
+		File: manifestPath,
 		Dependency: Dependency{
 			Package: Package{Name: v.ImpactedDependencyName},
 			Version: v.ImpactedDependencyVersion,

--- a/utils/gitlabreport/gitlabreport.go
+++ b/utils/gitlabreport/gitlabreport.go
@@ -196,9 +196,6 @@ func vulnerabilityToReport(v *formats.VulnerabilityOrViolationRow) Vulnerability
 	id := deterministicVulnID(v.ImpactedDependencyName, v.ImpactedDependencyVersion, v.IssueId, v.Cves)
 	identifiers := buildIdentifiers(v)
 	manifestPath := rowPreferredInputFile(v)
-	if manifestPath == "" {
-		manifestPath = manifestFileForTechnology(v.Technology)
-	}
 	location := Location{
 		File: manifestPath,
 		Dependency: Dependency{
@@ -207,9 +204,7 @@ func vulnerabilityToReport(v *formats.VulnerabilityOrViolationRow) Vulnerability
 		},
 	}
 	severity := normalizeSeverity(getSeverity(v))
-	// GitLab's vulnerability list "Description" column is built from the finding title (name) and
-	// manifest path — it does not show the JSON description body in that column. Include
-	// contextual analysis in name so it appears in the list; description holds summary only.
+	// Keep contextual analysis in title so it shows in GitLab's vulnerability list.
 	name := buildVulnerabilityNameWithContextualAnalysis(v)
 	desc := strings.TrimSpace(getSummary(v))
 	solution := ""

--- a/utils/gitlabreport/gitlabreport.go
+++ b/utils/gitlabreport/gitlabreport.go
@@ -37,10 +37,10 @@ type DependencyScanningReport struct {
 type ScanReport struct {
 	Analyzer  AnalyzerScanner `json:"analyzer"`
 	Scanner   AnalyzerScanner `json:"scanner"`
-	StartTime string          `json:"start_time"` // ISO8601 UTC yyyy-mm-ddThh:mm:ss
+	StartTime string          `json:"start_time"`
 	EndTime   string          `json:"end_time"`
-	Status    string          `json:"status"` // "success" or "failure"
-	Type      string          `json:"type"`   // "dependency_scanning"
+	Status    string          `json:"status"`
+	Type      string          `json:"type"`
 }
 
 type AnalyzerScanner struct {
@@ -56,20 +56,17 @@ type Vendor struct {
 }
 
 type VulnerabilityReport struct {
-	ID          string       `json:"id"`
-	Name        string       `json:"name,omitempty"`
-	Description string       `json:"description,omitempty"`
-	Severity    string       `json:"severity,omitempty"` // Info, Unknown, Low, Medium, High, Critical
-	Solution    string       `json:"solution,omitempty"`
-	Identifiers []Identifier `json:"identifiers"`
-	Location    Location     `json:"location"`
-	Links       []Link       `json:"links,omitempty"`
-	// Details is optional per GitLab schema (named-list item map). Reachable is set on CycloneDX
-	// components (gitlab:dependency_scanning_component:reachability), not here.
-	Details map[string]DetailNamedListItem `json:"details,omitempty"`
+	ID          string                         `json:"id"`
+	Name        string                         `json:"name,omitempty"`
+	Description string                         `json:"description,omitempty"`
+	Severity    string                         `json:"severity,omitempty"`
+	Solution    string                         `json:"solution,omitempty"`
+	Identifiers []Identifier                   `json:"identifiers"`
+	Location    Location                       `json:"location"`
+	Links       []Link                         `json:"links,omitempty"`
+	Details     map[string]DetailNamedListItem `json:"details,omitempty"`
 }
 
-// DetailNamedListItem merges named_field (name) with a detail payload (e.g. type "text" + value).
 type DetailNamedListItem struct {
 	Name  string `json:"name"`
 	Type  string `json:"type"` // "text"
@@ -120,9 +117,6 @@ func ConvertToGitLabDependencyScanningReport(scanResults *results.SecurityComman
 		}, nil
 	}
 
-	// Always include SCA vulnerabilities in this export. scanResults.IncludesVulnerabilities()
-	// reflects the interactive scan context (e.g. violation-only views); when false, jfrog-cli-security
-	// skips ParseCVEs and the GitLab JSON would be empty even with many SBOM CVEs — wrong for CI reports.
 	convertor := conversion.NewCommandResultsConvertor(conversion.ResultConvertParams{
 		IncludeVulnerabilities: true,
 		HasViolationContext:    scanResults.HasViolationContext(),
@@ -204,7 +198,6 @@ func vulnerabilityToReport(v *formats.VulnerabilityOrViolationRow) Vulnerability
 		},
 	}
 	severity := normalizeSeverity(getSeverity(v))
-	// Keep contextual analysis in title so it shows in GitLab's vulnerability list.
 	name := buildVulnerabilityNameWithContextualAnalysis(v)
 	desc := strings.TrimSpace(getSummary(v))
 	solution := ""
@@ -288,8 +281,6 @@ func buildIdentifiers(v *formats.VulnerabilityOrViolationRow) []Identifier {
 	return appendUniqueCWEIdentifiers(ids, v)
 }
 
-// appendUniqueCWEIdentifiers adds GitLab dependency-scanning identifiers with type "cwe" from each
-// CVE row's Cwe list (Xray simple JSON). GitLab aggregates these for dashboards such as "Top 10 CWEs".
 func appendUniqueCWEIdentifiers(ids []Identifier, v *formats.VulnerabilityOrViolationRow) []Identifier {
 	seen := make(map[string]struct{})
 	for _, id := range ids {
@@ -342,7 +333,6 @@ func normalizeCweID(raw string) string {
 	return ""
 }
 
-// cweNumericID returns digits-only CWE id, or empty if invalid.
 func cweNumericID(s string) string {
 	s = strings.TrimSpace(s)
 	if s == "" {
@@ -384,8 +374,6 @@ func getSummary(v *formats.VulnerabilityOrViolationRow) string {
 	return ""
 }
 
-// buildVulnerabilityNameWithContextualAnalysis sets the GitLab finding title to "CVE-ID (status)" using
-// aggregated contextual analysis for the row (same aggregation as Frogbot PR comments).
 func buildVulnerabilityNameWithContextualAnalysis(v *formats.VulnerabilityOrViolationRow) string {
 	base := v.IssueId
 	if len(v.Cves) > 0 && v.Cves[0].Id != "" {
@@ -397,7 +385,6 @@ func buildVulnerabilityNameWithContextualAnalysis(v *formats.VulnerabilityOrViol
 	return fmt.Sprintf("%s (%s)", base, aggregatedContextualAnalysisDisplay(v))
 }
 
-// aggregatedContextualAnalysisDisplay returns a human-readable status; NotScanned maps to "Not Covered".
 func aggregatedContextualAnalysisDisplay(v *formats.VulnerabilityOrViolationRow) string {
 	st := rowFinalApplicabilityStatus(v)
 	if st == jasutils.NotScanned || st.String() == "" {
@@ -440,7 +427,6 @@ func severitySortRank(normalized string) int {
 	}
 }
 
-// rowFinalApplicabilityStatus aggregates per-CVE applicability like Frogbot PR comments.
 func rowFinalApplicabilityStatus(v *formats.VulnerabilityOrViolationRow) jasutils.ApplicabilityStatus {
 	var statuses []jasutils.ApplicabilityStatus
 	for _, cve := range v.Cves {
@@ -451,7 +437,6 @@ func rowFinalApplicabilityStatus(v *formats.VulnerabilityOrViolationRow) jasutil
 	return results.GetFinalApplicabilityStatus(len(statuses) > 0, statuses)
 }
 
-// applicabilitySortRank orders rows within the same severity: Applicable first, Not Applicable last.
 func applicabilitySortRank(status jasutils.ApplicabilityStatus) int {
 	switch status {
 	case jasutils.Applicable:
@@ -492,6 +477,8 @@ func manifestFileForTechnology(tech techutils.Technology) string {
 	switch tech {
 	case techutils.Npm, techutils.Yarn:
 		return "package-lock.json"
+	case techutils.Pnpm:
+		return "pnpm-lock.yaml"
 	case techutils.Go:
 		return "go.sum"
 	case techutils.Pip, techutils.Pipenv:
@@ -505,7 +492,6 @@ func manifestFileForTechnology(tech techutils.Technology) string {
 	}
 }
 
-// WriteDependencyScanningReport writes the GitLab dependency-scanning report to outputDir/gl-dependency-scanning-report.json.
 func WriteDependencyScanningReport(outputDir string, report *DependencyScanningReport) error {
 	if outputDir == "" {
 		return fmt.Errorf("output directory is required")

--- a/utils/gitlabreport/gitlabreport.go
+++ b/utils/gitlabreport/gitlabreport.go
@@ -69,7 +69,7 @@ type VulnerabilityReport struct {
 
 type DetailNamedListItem struct {
 	Name  string `json:"name"`
-	Type  string `json:"type"` // "text"
+	Type  string `json:"type"`
 	Value string `json:"value"`
 }
 
@@ -382,15 +382,12 @@ func buildVulnerabilityNameWithContextualAnalysis(v *formats.VulnerabilityOrViol
 	if base == "" {
 		return ""
 	}
-	return fmt.Sprintf("%s (%s)", base, aggregatedContextualAnalysisDisplay(v))
-}
-
-func aggregatedContextualAnalysisDisplay(v *formats.VulnerabilityOrViolationRow) string {
 	st := rowFinalApplicabilityStatus(v)
-	if st == jasutils.NotScanned || st.String() == "" {
-		return jasutils.NotCovered.String()
+	display := st.String()
+	if st == jasutils.NotScanned || display == "" {
+		display = jasutils.NotCovered.String()
 	}
-	return st.String()
+	return fmt.Sprintf("%s (%s)", base, display)
 }
 
 func sortVulnerabilityRowsForGitLab(vulns []formats.VulnerabilityOrViolationRow) {

--- a/utils/gitlabreport/gitlabreport_test.go
+++ b/utils/gitlabreport/gitlabreport_test.go
@@ -207,27 +207,19 @@ func TestVulnerabilityToReport(t *testing.T) {
 			assert.Equal(t, tt.wantManifest, got.Location.File)
 			if tt.name == "CVE name and link" {
 				assert.Equal(t, "Test summary", got.Description)
-				require.Contains(t, got.Details, "reachable")
-				item := got.Details["reachable"]
-				assert.Equal(t, "Reachable", item.Name)
-				assert.Equal(t, "text", item.Type)
-				assert.Equal(t, "CVE-2021-1234 (Not Covered).", item.Value)
+				assert.Nil(t, got.Details)
 			}
 			if tt.name == "contextual analysis in reachable detail" {
 				assert.Equal(t, "Details here", got.Description)
-				require.Contains(t, got.Details, "reachable")
-				item := got.Details["reachable"]
-				assert.Equal(t, "CVE-2023-1 (Applicable). CVE-2023-2 (Not Applicable).", item.Value)
+				assert.Nil(t, got.Details)
 			}
 			if tt.name == "non-CVE issue id adds xray identifier" {
 				assert.Empty(t, got.Description)
-				require.Contains(t, got.Details, "reachable")
-				assert.Equal(t, jasutils.NotCovered.String(), got.Details["reachable"].Value)
+				assert.Nil(t, got.Details)
 			}
 			if tt.name == "CVE from issueId when cves slice empty" {
 				assert.Equal(t, "from issue id only", got.Description)
-				require.Contains(t, got.Details, "reachable")
-				assert.Equal(t, jasutils.NotCovered.String(), got.Details["reachable"].Value)
+				assert.Nil(t, got.Details)
 			}
 			if tt.name == "fallback identifier when no CVE or issue id" {
 				assert.Nil(t, got.Details)
@@ -262,11 +254,8 @@ func TestGitLabReportJSON_identifierValueIsCVE(t *testing.T) {
 	assert.Contains(t, string(raw), `"type":"cve"`)
 	assert.Contains(t, string(raw), `"name":"CVE-2021-9999"`)
 	assert.Contains(t, string(raw), `"value":"CVE-2021-9999"`)
-	assert.Contains(t, string(raw), `"details":`)
-	assert.Contains(t, string(raw), `"reachable":{`)
-	assert.Contains(t, string(raw), `"name":"Reachable"`)
-	assert.Contains(t, string(raw), `"value":"CVE-2021-9999 (Not Covered)."`)
-	assert.NotContains(t, string(raw), `"details":{"type":"named-list"`)
+	assert.NotContains(t, string(raw), `"reachable"`)
+	assert.NotContains(t, string(raw), `"details":`)
 	assert.Contains(t, string(raw), `"type":"cwe"`)
 	assert.Contains(t, string(raw), `"name":"CWE-1004"`)
 	assert.Contains(t, string(raw), `"value":"CWE-1004"`)

--- a/utils/gitlabreport/gitlabreport_test.go
+++ b/utils/gitlabreport/gitlabreport_test.go
@@ -127,7 +127,7 @@ func TestVulnerabilityToReport(t *testing.T) {
 			identifierTypes: []string{"cve", "xray"},
 		},
 		{
-			name: "contextual analysis in description",
+			name: "contextual analysis in reachable detail",
 			row: formats.VulnerabilityOrViolationRow{
 				IssueId: "XRAY-99",
 				ImpactedDependencyDetails: formats.ImpactedDependencyDetails{
@@ -203,10 +203,32 @@ func TestVulnerabilityToReport(t *testing.T) {
 			assert.Equal(t, tt.wantSeverity, got.Severity)
 			assert.Equal(t, tt.wantManifest, got.Location.File)
 			if tt.name == "CVE name and link" {
-				assert.Equal(t, "CVE-2021-1234 (Not Covered).\n\nTest summary", got.Description)
+				assert.Equal(t, "Test summary", got.Description)
+				require.NotNil(t, got.Details)
+				assert.Equal(t, "named-list", got.Details.Type)
+				item := got.Details.Items["reachable"]
+				assert.Equal(t, "Reachable", item.Name)
+				assert.Equal(t, "text", item.Type)
+				assert.Equal(t, "CVE-2021-1234 (Not Covered).", item.Value)
 			}
-			if tt.name == "contextual analysis in description" {
-				assert.Equal(t, "CVE-2023-1 (Applicable). CVE-2023-2 (Not Applicable).\n\nDetails here", got.Description)
+			if tt.name == "contextual analysis in reachable detail" {
+				assert.Equal(t, "Details here", got.Description)
+				require.NotNil(t, got.Details)
+				item := got.Details.Items["reachable"]
+				assert.Equal(t, "CVE-2023-1 (Applicable). CVE-2023-2 (Not Applicable).", item.Value)
+			}
+			if tt.name == "non-CVE issue id adds xray identifier" {
+				assert.Empty(t, got.Description)
+				require.NotNil(t, got.Details)
+				assert.Equal(t, jasutils.NotCovered.String(), got.Details.Items["reachable"].Value)
+			}
+			if tt.name == "CVE from issueId when cves slice empty" {
+				assert.Equal(t, "from issue id only", got.Description)
+				require.NotNil(t, got.Details)
+				assert.Equal(t, jasutils.NotCovered.String(), got.Details.Items["reachable"].Value)
+			}
+			if tt.name == "fallback identifier when no CVE or issue id" {
+				assert.Nil(t, got.Details)
 			}
 			if tt.wantSolution != "" {
 				assert.Equal(t, tt.wantSolution, got.Solution)
@@ -238,6 +260,10 @@ func TestGitLabReportJSON_identifierValueIsCVE(t *testing.T) {
 	assert.Contains(t, string(raw), `"type":"cve"`)
 	assert.Contains(t, string(raw), `"name":"CVE-2021-9999"`)
 	assert.Contains(t, string(raw), `"value":"CVE-2021-9999"`)
+	assert.Contains(t, string(raw), `"details":`)
+	assert.Contains(t, string(raw), `"type":"named-list"`)
+	assert.Contains(t, string(raw), `"name":"Reachable"`)
+	assert.Contains(t, string(raw), `"value":"CVE-2021-9999 (Not Covered)."`)
 }
 
 func scanResultsWithSbomOnly() *results.SecurityCommandResults {

--- a/utils/gitlabreport/gitlabreport_test.go
+++ b/utils/gitlabreport/gitlabreport_test.go
@@ -1,0 +1,256 @@
+package gitlabreport
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/CycloneDX/cyclonedx-go"
+	"github.com/jfrog/jfrog-cli-security/utils/formats"
+	"github.com/jfrog/jfrog-cli-security/utils/results"
+	"github.com/jfrog/jfrog-cli-security/utils/techutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeSeverity(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"critical", "Critical"},
+		{"CRITICAL", "Critical"},
+		{"high", "High"},
+		{"medium", "Medium"},
+		{"moderate", "Medium"},
+		{"low", "Low"},
+		{"info", "Info"},
+		{"informational", "Info"},
+		{"", "Unknown"},
+		{"weird", "Unknown"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.expected, normalizeSeverity(tt.input))
+		})
+	}
+}
+
+func TestManifestFileForTechnology(t *testing.T) {
+	tests := []struct {
+		tech     techutils.Technology
+		expected string
+	}{
+		{techutils.Npm, "package-lock.json"},
+		{techutils.Yarn, "package-lock.json"},
+		{techutils.Go, "go.sum"},
+		{techutils.Pip, "requirements.txt"},
+		{techutils.Pipenv, "requirements.txt"},
+		{techutils.Maven, "pom.xml"},
+		{techutils.Nuget, "packages.config"},
+		{techutils.Technology("unknown"), "manifest"},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.tech), func(t *testing.T) {
+			assert.Equal(t, tt.expected, manifestFileForTechnology(tt.tech))
+		})
+	}
+}
+
+func TestFormatGitLabTime(t *testing.T) {
+	loc := time.FixedZone("CST", -6*3600)
+	ts := time.Date(2024, 6, 1, 12, 30, 45, 0, loc)
+	assert.Equal(t, "2024-06-01T18:30:45", formatGitLabTime(ts))
+}
+
+func TestDeterministicVulnID(t *testing.T) {
+	id1 := deterministicVulnID("pkg", "1.0.0", "XRAY-1", []formats.CveRow{{Id: "CVE-2024-1"}})
+	id2 := deterministicVulnID("pkg", "1.0.0", "XRAY-1", []formats.CveRow{{Id: "CVE-2024-1"}})
+	id3 := deterministicVulnID("pkg", "1.0.0", "XRAY-1", []formats.CveRow{{Id: "CVE-2024-2"}})
+	assert.Equal(t, id1, id2)
+	assert.NotEqual(t, id1, id3)
+	assert.Regexp(t, `^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`, id1)
+}
+
+func TestMakeAnalyzerScanner(t *testing.T) {
+	tests := []struct {
+		version string
+		wantVer string
+	}{
+		{"1.2.3", "1.2.3"},
+		{"", "0.0.0"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.wantVer, func(t *testing.T) {
+			got := makeAnalyzerScanner(tt.version)
+			assert.Equal(t, frogbotAnalyzerID, got.ID)
+			assert.Equal(t, frogbotAnalyzerName, got.Name)
+			assert.Equal(t, tt.wantVer, got.Version)
+			assert.Equal(t, frogbotVendorName, got.Vendor.Name)
+		})
+	}
+}
+
+func TestVulnerabilityToReport(t *testing.T) {
+	tests := []struct {
+		name string
+		row  formats.VulnerabilityOrViolationRow
+		// spot checks
+		wantName        string
+		wantSeverity    string
+		wantManifest    string
+		wantSolution    string
+		identifierTypes []string
+	}{
+		{
+			name: "CVE name and link",
+			row: formats.VulnerabilityOrViolationRow{
+				IssueId: "XRAY-99",
+				ImpactedDependencyDetails: formats.ImpactedDependencyDetails{
+					ImpactedDependencyName:    "lodash",
+					ImpactedDependencyVersion: "4.17.20",
+					SeverityDetails:           formats.SeverityDetails{Severity: "high"},
+				},
+				Cves:          []formats.CveRow{{Id: "CVE-2021-1234"}},
+				Summary:       "Test summary",
+				Technology:    techutils.Npm,
+				FixedVersions: []string{"4.17.21"},
+			},
+			wantName:        "CVE-2021-1234",
+			wantSeverity:    "High",
+			wantManifest:    "package-lock.json",
+			wantSolution:    "Upgrade lodash to version 4.17.21 or later.",
+			identifierTypes: []string{"cve", "xray"},
+		},
+		{
+			name: "non-CVE issue id adds xray identifier",
+			row: formats.VulnerabilityOrViolationRow{
+				IssueId: "XRAY-100",
+				ImpactedDependencyDetails: formats.ImpactedDependencyDetails{
+					ImpactedDependencyName:    "foo",
+					ImpactedDependencyVersion: "1.0.0",
+					SeverityDetails:           formats.SeverityDetails{Severity: "low"},
+				},
+				Technology: techutils.Go,
+			},
+			wantName:        "XRAY-100",
+			wantSeverity:    "Low",
+			wantManifest:    "go.sum",
+			identifierTypes: []string{"xray"},
+		},
+		{
+			name: "fallback identifier when no CVE or issue id",
+			row: formats.VulnerabilityOrViolationRow{
+				ImpactedDependencyDetails: formats.ImpactedDependencyDetails{
+					ImpactedDependencyName:    "orphan",
+					ImpactedDependencyVersion: "0.0.1",
+				},
+				Technology: techutils.Maven,
+			},
+			wantName:        "",
+			wantSeverity:    "Unknown",
+			wantManifest:    "pom.xml",
+			identifierTypes: []string{"other"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := vulnerabilityToReport(&tt.row)
+			assert.Equal(t, tt.wantName, got.Name)
+			assert.Equal(t, tt.wantSeverity, got.Severity)
+			assert.Equal(t, tt.wantManifest, got.Location.File)
+			if tt.wantSolution != "" {
+				assert.Equal(t, tt.wantSolution, got.Solution)
+			}
+			require.Len(t, got.Identifiers, len(tt.identifierTypes))
+			for i, wantType := range tt.identifierTypes {
+				assert.Equal(t, wantType, got.Identifiers[i].Type)
+			}
+		})
+	}
+}
+
+func scanResultsWithSbomOnly() *results.SecurityCommandResults {
+	components := []cyclonedx.Component{
+		{BOMRef: "c1", Type: cyclonedx.ComponentTypeLibrary, Name: "express", Version: "4.18.2"},
+	}
+	bom := cyclonedx.NewBOM()
+	bom.Components = &components
+	return &results.SecurityCommandResults{
+		ResultsMetaData: results.ResultsMetaData{StartTime: time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)},
+		Targets: []*results.TargetResults{{
+			ScanTarget: results.ScanTarget{Target: "t1"},
+			ScaResults: &results.ScaScanResults{Sbom: bom},
+		}},
+	}
+}
+
+func TestConvertToGitLabDependencyScanningReport(t *testing.T) {
+	start := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
+	end := time.Date(2024, 1, 15, 10, 35, 0, 0, time.UTC)
+	version := "9.9.9"
+
+	t.Run("nil scan results", func(t *testing.T) {
+		report, err := ConvertToGitLabDependencyScanningReport(nil, start, end, version)
+		require.NoError(t, err)
+		require.NotNil(t, report)
+		assert.Equal(t, "success", report.Scan.Status)
+		assert.Empty(t, report.Vulnerabilities)
+		assert.Equal(t, gitLabReportSchemaVersion, report.Version)
+		assert.Equal(t, gitLabReportSchemaURL, report.Schema)
+		assert.Equal(t, "dependency_scanning", report.Scan.Type)
+		assert.Equal(t, formatGitLabTime(start), report.Scan.StartTime)
+		assert.Equal(t, formatGitLabTime(end), report.Scan.EndTime)
+		assert.Equal(t, version, report.Scan.Analyzer.Version)
+	})
+
+	t.Run("scan with SBOM only", func(t *testing.T) {
+		report, err := ConvertToGitLabDependencyScanningReport(scanResultsWithSbomOnly(), start, end, version)
+		require.NoError(t, err)
+		assert.Equal(t, "success", report.Scan.Status)
+	})
+
+	t.Run("failure status when GetErrors returns error", func(t *testing.T) {
+		sr := scanResultsWithSbomOnly()
+		sr.GeneralError = errors.New("scanner failed")
+		report, err := ConvertToGitLabDependencyScanningReport(sr, start, end, version)
+		require.NoError(t, err)
+		assert.Equal(t, "failure", report.Scan.Status)
+	})
+}
+
+func TestWriteDependencyScanningReport(t *testing.T) {
+	t.Run("empty output dir", func(t *testing.T) {
+		err := WriteDependencyScanningReport("", &DependencyScanningReport{})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "output directory is required")
+	})
+
+	t.Run("writes JSON file", func(t *testing.T) {
+		dir := t.TempDir()
+		report := &DependencyScanningReport{
+			Version: gitLabReportSchemaVersion,
+			Schema:  gitLabReportSchemaURL,
+			Scan: ScanReport{
+				Status:    "success",
+				Type:      "dependency_scanning",
+				StartTime: "2024-01-01T00:00:00",
+				EndTime:   "2024-01-01T00:01:00",
+				Analyzer:  makeAnalyzerScanner("1.0.0"),
+				Scanner:   makeAnalyzerScanner("1.0.0"),
+			},
+			Vulnerabilities: []VulnerabilityReport{},
+		}
+		require.NoError(t, WriteDependencyScanningReport(dir, report))
+		path := filepath.Join(dir, "gl-dependency-scanning-report.json")
+		data, err := os.ReadFile(path)
+		require.NoError(t, err)
+		var decoded DependencyScanningReport
+		require.NoError(t, json.Unmarshal(data, &decoded))
+		assert.Equal(t, gitLabReportSchemaVersion, decoded.Version)
+		assert.Equal(t, "success", decoded.Scan.Status)
+	})
+}

--- a/utils/gitlabreport/gitlabreport_test.go
+++ b/utils/gitlabreport/gitlabreport_test.go
@@ -3,6 +3,7 @@ package gitlabreport
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -115,7 +116,7 @@ func TestVulnerabilityToReport(t *testing.T) {
 					ImpactedDependencyVersion: "4.17.20",
 					SeverityDetails:           formats.SeverityDetails{Severity: "high"},
 				},
-				Cves:          []formats.CveRow{{Id: "CVE-2021-1234"}},
+				Cves:          []formats.CveRow{{Id: "CVE-2021-1234", Cwe: []string{"CWE-502", "502"}}}, // duplicate normalized → one CWE id
 				Summary:       "Test summary",
 				Technology:    techutils.Npm,
 				FixedVersions: []string{"4.17.21"},
@@ -124,7 +125,7 @@ func TestVulnerabilityToReport(t *testing.T) {
 			wantSeverity:    "High",
 			wantManifest:    "package-lock.json",
 			wantSolution:    "Upgrade lodash to version 4.17.21 or later.",
-			identifierTypes: []string{"cve", "xray"},
+			identifierTypes: []string{"cve", "xray", "cwe"},
 		},
 		{
 			name: "contextual analysis in reachable detail",
@@ -136,8 +137,8 @@ func TestVulnerabilityToReport(t *testing.T) {
 					SeverityDetails:           formats.SeverityDetails{Severity: "low"},
 				},
 				Cves: []formats.CveRow{
-					{Id: "CVE-2023-1", Applicability: &formats.Applicability{Status: jasutils.Applicable.String()}},
-					{Id: "CVE-2023-2", Applicability: &formats.Applicability{Status: jasutils.NotApplicable.String()}},
+					{Id: "CVE-2023-1", Cwe: []string{"CWE-79"}, Applicability: &formats.Applicability{Status: jasutils.Applicable.String()}},
+					{Id: "CVE-2023-2", Cwe: []string{"cwe-89"}, Applicability: &formats.Applicability{Status: jasutils.NotApplicable.String()}},
 				},
 				Summary:    "Details here",
 				Technology: techutils.Npm,
@@ -145,7 +146,7 @@ func TestVulnerabilityToReport(t *testing.T) {
 			wantName:        "CVE-2023-1 (Applicable)",
 			wantSeverity:    "Low",
 			wantManifest:    "package-lock.json",
-			identifierTypes: []string{"cve", "cve", "xray"},
+			identifierTypes: []string{"cve", "cve", "xray", "cwe", "cwe"},
 		},
 		{
 			name: "non-CVE issue id adds xray identifier",
@@ -156,12 +157,13 @@ func TestVulnerabilityToReport(t *testing.T) {
 					ImpactedDependencyVersion: "1.0.0",
 					SeverityDetails:           formats.SeverityDetails{Severity: "low"},
 				},
+				Cves:       []formats.CveRow{{Cwe: []string{"20"}}},
 				Technology: techutils.Go,
 			},
 			wantName:        "XRAY-100 (Not Covered)",
 			wantSeverity:    "Low",
 			wantManifest:    "go.sum",
-			identifierTypes: []string{"xray"},
+			identifierTypes: []string{"xray", "cwe"},
 		},
 		{
 			name: "fallback identifier when no CVE or issue id",
@@ -170,12 +172,13 @@ func TestVulnerabilityToReport(t *testing.T) {
 					ImpactedDependencyName:    "orphan",
 					ImpactedDependencyVersion: "0.0.1",
 				},
+				Cves:       []formats.CveRow{{Cwe: []string{"CWE-787"}}},
 				Technology: techutils.Maven,
 			},
 			wantName:        "",
 			wantSeverity:    "Unknown",
 			wantManifest:    "pom.xml",
-			identifierTypes: []string{"other"},
+			identifierTypes: []string{"other", "cwe"},
 		},
 		{
 			name: "CVE from issueId when cves slice empty",
@@ -186,14 +189,14 @@ func TestVulnerabilityToReport(t *testing.T) {
 					ImpactedDependencyVersion: "1.0.0",
 					SeverityDetails:           formats.SeverityDetails{Severity: "high"},
 				},
-				Cves:       nil,
+				Cves:       []formats.CveRow{{Cwe: []string{"22"}}},
 				Summary:    "from issue id only",
 				Technology: techutils.Maven,
 			},
 			wantName:        "CVE-2020-9999 (Not Covered)",
 			wantSeverity:    "High",
 			wantManifest:    "pom.xml",
-			identifierTypes: []string{"cve"},
+			identifierTypes: []string{"cve", "cwe"},
 		},
 	}
 	for _, tt := range tests {
@@ -251,7 +254,7 @@ func TestGitLabReportJSON_identifierValueIsCVE(t *testing.T) {
 			ImpactedDependencyVersion: "1.0.0",
 			SeverityDetails:           formats.SeverityDetails{Severity: "high"},
 		},
-		Cves:       []formats.CveRow{{Id: "CVE-2021-9999"}},
+		Cves:       []formats.CveRow{{Id: "CVE-2021-9999", Cwe: []string{"1004"}}},
 		Technology: techutils.Npm,
 	}
 	rep := vulnerabilityToReport(&row)
@@ -264,6 +267,27 @@ func TestGitLabReportJSON_identifierValueIsCVE(t *testing.T) {
 	assert.Contains(t, string(raw), `"type":"named-list"`)
 	assert.Contains(t, string(raw), `"name":"Reachable"`)
 	assert.Contains(t, string(raw), `"value":"CVE-2021-9999 (Not Covered)."`)
+	assert.Contains(t, string(raw), `"type":"cwe"`)
+	assert.Contains(t, string(raw), `"name":"CWE-1004"`)
+	assert.Contains(t, string(raw), `"value":"CWE-1004"`)
+}
+
+func TestNormalizeCweID(t *testing.T) {
+	tests := []struct{ in, want string }{
+		{"CWE-79", "CWE-79"},
+		{"cwe-89", "CWE-89"},
+		{"787", "CWE-787"},
+		{"  22  ", "CWE-22"},
+		{"", ""},
+		{"CWE-", ""},
+		{"CWE-notnum", ""},
+		{"nope", ""},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%q", tt.in), func(t *testing.T) {
+			assert.Equal(t, tt.want, normalizeCweID(tt.in))
+		})
+	}
 }
 
 func scanResultsWithSbomOnly() *results.SecurityCommandResults {

--- a/utils/gitlabreport/gitlabreport_test.go
+++ b/utils/gitlabreport/gitlabreport_test.go
@@ -177,6 +177,24 @@ func TestVulnerabilityToReport(t *testing.T) {
 			wantManifest:    "pom.xml",
 			identifierTypes: []string{"other"},
 		},
+		{
+			name: "CVE from issueId when cves slice empty",
+			row: formats.VulnerabilityOrViolationRow{
+				IssueId: "CVE-2020-9999",
+				ImpactedDependencyDetails: formats.ImpactedDependencyDetails{
+					ImpactedDependencyName:    "dep",
+					ImpactedDependencyVersion: "1.0.0",
+					SeverityDetails:           formats.SeverityDetails{Severity: "high"},
+				},
+				Cves:       nil,
+				Summary:    "from issue id only",
+				Technology: techutils.Maven,
+			},
+			wantName:        "CVE-2020-9999 (Not Covered)",
+			wantSeverity:    "High",
+			wantManifest:    "pom.xml",
+			identifierTypes: []string{"cve"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -196,9 +214,30 @@ func TestVulnerabilityToReport(t *testing.T) {
 			require.Len(t, got.Identifiers, len(tt.identifierTypes))
 			for i, wantType := range tt.identifierTypes {
 				assert.Equal(t, wantType, got.Identifiers[i].Type)
+				assert.NotEmpty(t, got.Identifiers[i].Value, "identifier value must be set for GitLab vulnerability report")
+				assert.Equal(t, got.Identifiers[i].Value, got.Identifiers[i].Name, "identifier name should match value for GitLab UI")
 			}
 		})
 	}
+}
+
+func TestGitLabReportJSON_identifierValueIsCVE(t *testing.T) {
+	row := formats.VulnerabilityOrViolationRow{
+		IssueId: "XRAY-1",
+		ImpactedDependencyDetails: formats.ImpactedDependencyDetails{
+			ImpactedDependencyName:    "lib",
+			ImpactedDependencyVersion: "1.0.0",
+			SeverityDetails:           formats.SeverityDetails{Severity: "high"},
+		},
+		Cves:       []formats.CveRow{{Id: "CVE-2021-9999"}},
+		Technology: techutils.Npm,
+	}
+	rep := vulnerabilityToReport(&row)
+	raw, err := json.Marshal(rep)
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), `"type":"cve"`)
+	assert.Contains(t, string(raw), `"name":"CVE-2021-9999"`)
+	assert.Contains(t, string(raw), `"value":"CVE-2021-9999"`)
 }
 
 func scanResultsWithSbomOnly() *results.SecurityCommandResults {

--- a/utils/gitlabreport/gitlabreport_test.go
+++ b/utils/gitlabreport/gitlabreport_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/CycloneDX/cyclonedx-go"
 	"github.com/jfrog/jfrog-cli-security/utils/formats"
+	"github.com/jfrog/jfrog-cli-security/utils/jasutils"
 	"github.com/jfrog/jfrog-cli-security/utils/results"
 	"github.com/jfrog/jfrog-cli-security/utils/techutils"
 	"github.com/stretchr/testify/assert"
@@ -119,11 +120,32 @@ func TestVulnerabilityToReport(t *testing.T) {
 				Technology:    techutils.Npm,
 				FixedVersions: []string{"4.17.21"},
 			},
-			wantName:        "CVE-2021-1234",
+			wantName:        "CVE-2021-1234 (Not Covered)",
 			wantSeverity:    "High",
 			wantManifest:    "package-lock.json",
 			wantSolution:    "Upgrade lodash to version 4.17.21 or later.",
 			identifierTypes: []string{"cve", "xray"},
+		},
+		{
+			name: "contextual analysis in description",
+			row: formats.VulnerabilityOrViolationRow{
+				IssueId: "XRAY-99",
+				ImpactedDependencyDetails: formats.ImpactedDependencyDetails{
+					ImpactedDependencyName:    "pkg",
+					ImpactedDependencyVersion: "1.0.0",
+					SeverityDetails:           formats.SeverityDetails{Severity: "low"},
+				},
+				Cves: []formats.CveRow{
+					{Id: "CVE-2023-1", Applicability: &formats.Applicability{Status: jasutils.Applicable.String()}},
+					{Id: "CVE-2023-2", Applicability: &formats.Applicability{Status: jasutils.NotApplicable.String()}},
+				},
+				Summary:    "Details here",
+				Technology: techutils.Npm,
+			},
+			wantName:        "CVE-2023-1 (Applicable)",
+			wantSeverity:    "Low",
+			wantManifest:    "package-lock.json",
+			identifierTypes: []string{"cve", "cve", "xray"},
 		},
 		{
 			name: "non-CVE issue id adds xray identifier",
@@ -136,7 +158,7 @@ func TestVulnerabilityToReport(t *testing.T) {
 				},
 				Technology: techutils.Go,
 			},
-			wantName:        "XRAY-100",
+			wantName:        "XRAY-100 (Not Covered)",
 			wantSeverity:    "Low",
 			wantManifest:    "go.sum",
 			identifierTypes: []string{"xray"},
@@ -162,6 +184,12 @@ func TestVulnerabilityToReport(t *testing.T) {
 			assert.Equal(t, tt.wantName, got.Name)
 			assert.Equal(t, tt.wantSeverity, got.Severity)
 			assert.Equal(t, tt.wantManifest, got.Location.File)
+			if tt.name == "CVE name and link" {
+				assert.Equal(t, "CVE-2021-1234 (Not Covered).\n\nTest summary", got.Description)
+			}
+			if tt.name == "contextual analysis in description" {
+				assert.Equal(t, "CVE-2023-1 (Applicable). CVE-2023-2 (Not Applicable).\n\nDetails here", got.Description)
+			}
 			if tt.wantSolution != "" {
 				assert.Equal(t, tt.wantSolution, got.Solution)
 			}
@@ -220,6 +248,39 @@ func TestConvertToGitLabDependencyScanningReport(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "failure", report.Scan.Status)
 	})
+}
+
+func TestSortVulnerabilityRowsForGitLab(t *testing.T) {
+	rows := []formats.VulnerabilityOrViolationRow{
+		{
+			IssueId: "b-low-na",
+			ImpactedDependencyDetails: formats.ImpactedDependencyDetails{
+				ImpactedDependencyName: "p1", ImpactedDependencyVersion: "1",
+				SeverityDetails: formats.SeverityDetails{Severity: "low"},
+			},
+			Cves: []formats.CveRow{{Id: "CVE-B", Applicability: &formats.Applicability{Status: jasutils.NotApplicable.String()}}},
+		},
+		{
+			IssueId: "a-high-app",
+			ImpactedDependencyDetails: formats.ImpactedDependencyDetails{
+				ImpactedDependencyName: "p2", ImpactedDependencyVersion: "1",
+				SeverityDetails: formats.SeverityDetails{Severity: "high"},
+			},
+			Cves: []formats.CveRow{{Id: "CVE-A", Applicability: &formats.Applicability{Status: jasutils.Applicable.String()}}},
+		},
+		{
+			IssueId: "c-low-app",
+			ImpactedDependencyDetails: formats.ImpactedDependencyDetails{
+				ImpactedDependencyName: "p3", ImpactedDependencyVersion: "1",
+				SeverityDetails: formats.SeverityDetails{Severity: "low"},
+			},
+			Cves: []formats.CveRow{{Id: "CVE-C", Applicability: &formats.Applicability{Status: jasutils.Applicable.String()}}},
+		},
+	}
+	sortVulnerabilityRowsForGitLab(rows)
+	assert.Equal(t, "a-high-app", rows[0].IssueId)
+	assert.Equal(t, "c-low-app", rows[1].IssueId)
+	assert.Equal(t, "b-low-na", rows[2].IssueId)
 }
 
 func TestWriteDependencyScanningReport(t *testing.T) {

--- a/utils/gitlabreport/gitlabreport_test.go
+++ b/utils/gitlabreport/gitlabreport_test.go
@@ -207,28 +207,27 @@ func TestVulnerabilityToReport(t *testing.T) {
 			assert.Equal(t, tt.wantManifest, got.Location.File)
 			if tt.name == "CVE name and link" {
 				assert.Equal(t, "Test summary", got.Description)
-				require.NotNil(t, got.Details)
-				assert.Equal(t, "named-list", got.Details.Type)
-				item := got.Details.Items["reachable"]
+				require.Contains(t, got.Details, "reachable")
+				item := got.Details["reachable"]
 				assert.Equal(t, "Reachable", item.Name)
 				assert.Equal(t, "text", item.Type)
 				assert.Equal(t, "CVE-2021-1234 (Not Covered).", item.Value)
 			}
 			if tt.name == "contextual analysis in reachable detail" {
 				assert.Equal(t, "Details here", got.Description)
-				require.NotNil(t, got.Details)
-				item := got.Details.Items["reachable"]
+				require.Contains(t, got.Details, "reachable")
+				item := got.Details["reachable"]
 				assert.Equal(t, "CVE-2023-1 (Applicable). CVE-2023-2 (Not Applicable).", item.Value)
 			}
 			if tt.name == "non-CVE issue id adds xray identifier" {
 				assert.Empty(t, got.Description)
-				require.NotNil(t, got.Details)
-				assert.Equal(t, jasutils.NotCovered.String(), got.Details.Items["reachable"].Value)
+				require.Contains(t, got.Details, "reachable")
+				assert.Equal(t, jasutils.NotCovered.String(), got.Details["reachable"].Value)
 			}
 			if tt.name == "CVE from issueId when cves slice empty" {
 				assert.Equal(t, "from issue id only", got.Description)
-				require.NotNil(t, got.Details)
-				assert.Equal(t, jasutils.NotCovered.String(), got.Details.Items["reachable"].Value)
+				require.Contains(t, got.Details, "reachable")
+				assert.Equal(t, jasutils.NotCovered.String(), got.Details["reachable"].Value)
 			}
 			if tt.name == "fallback identifier when no CVE or issue id" {
 				assert.Nil(t, got.Details)
@@ -264,9 +263,10 @@ func TestGitLabReportJSON_identifierValueIsCVE(t *testing.T) {
 	assert.Contains(t, string(raw), `"name":"CVE-2021-9999"`)
 	assert.Contains(t, string(raw), `"value":"CVE-2021-9999"`)
 	assert.Contains(t, string(raw), `"details":`)
-	assert.Contains(t, string(raw), `"type":"named-list"`)
+	assert.Contains(t, string(raw), `"reachable":{`)
 	assert.Contains(t, string(raw), `"name":"Reachable"`)
 	assert.Contains(t, string(raw), `"value":"CVE-2021-9999 (Not Covered)."`)
+	assert.NotContains(t, string(raw), `"details":{"type":"named-list"`)
 	assert.Contains(t, string(raw), `"type":"cwe"`)
 	assert.Contains(t, string(raw), `"name":"CWE-1004"`)
 	assert.Contains(t, string(raw), `"value":"CWE-1004"`)

--- a/utils/gitlabreport/gitlabreport_test.go
+++ b/utils/gitlabreport/gitlabreport_test.go
@@ -98,10 +98,10 @@ func TestMakeAnalyzerScanner(t *testing.T) {
 
 func TestVulnerabilityToReport(t *testing.T) {
 	tests := []struct {
-		name string
-		row  formats.VulnerabilityOrViolationRow
-		// spot checks
+		name            string
+		row             formats.VulnerabilityOrViolationRow
 		wantName        string
+		wantDescription string
 		wantSeverity    string
 		wantManifest    string
 		wantSolution    string
@@ -122,13 +122,14 @@ func TestVulnerabilityToReport(t *testing.T) {
 				FixedVersions: []string{"4.17.21"},
 			},
 			wantName:        "CVE-2021-1234 (Not Covered)",
+			wantDescription: "Test summary",
 			wantSeverity:    "High",
 			wantManifest:    "package-lock.json",
 			wantSolution:    "Upgrade lodash to version 4.17.21 or later.",
 			identifierTypes: []string{"cve", "xray", "cwe"},
 		},
 		{
-			name: "contextual analysis in reachable detail",
+			name: "contextual analysis in name",
 			row: formats.VulnerabilityOrViolationRow{
 				IssueId: "XRAY-99",
 				ImpactedDependencyDetails: formats.ImpactedDependencyDetails{
@@ -144,6 +145,7 @@ func TestVulnerabilityToReport(t *testing.T) {
 				Technology: techutils.Npm,
 			},
 			wantName:        "CVE-2023-1 (Applicable)",
+			wantDescription: "Details here",
 			wantSeverity:    "Low",
 			wantManifest:    "package-lock.json",
 			identifierTypes: []string{"cve", "cve", "xray", "cwe", "cwe"},
@@ -161,6 +163,7 @@ func TestVulnerabilityToReport(t *testing.T) {
 				Technology: techutils.Go,
 			},
 			wantName:        "XRAY-100 (Not Covered)",
+			wantDescription: "",
 			wantSeverity:    "Low",
 			wantManifest:    "go.sum",
 			identifierTypes: []string{"xray", "cwe"},
@@ -176,12 +179,13 @@ func TestVulnerabilityToReport(t *testing.T) {
 				Technology: techutils.Maven,
 			},
 			wantName:        "",
+			wantDescription: "",
 			wantSeverity:    "Unknown",
 			wantManifest:    "pom.xml",
 			identifierTypes: []string{"other", "cwe"},
 		},
 		{
-			name: "CVE from issueId when cves slice empty",
+			name: "CVE from issueId when cves slice has no id",
 			row: formats.VulnerabilityOrViolationRow{
 				IssueId: "CVE-2020-9999",
 				ImpactedDependencyDetails: formats.ImpactedDependencyDetails{
@@ -194,6 +198,7 @@ func TestVulnerabilityToReport(t *testing.T) {
 				Technology: techutils.Maven,
 			},
 			wantName:        "CVE-2020-9999 (Not Covered)",
+			wantDescription: "from issue id only",
 			wantSeverity:    "High",
 			wantManifest:    "pom.xml",
 			identifierTypes: []string{"cve", "cwe"},
@@ -203,30 +208,11 @@ func TestVulnerabilityToReport(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := vulnerabilityToReport(&tt.row)
 			assert.Equal(t, tt.wantName, got.Name)
+			assert.Equal(t, tt.wantDescription, got.Description)
 			assert.Equal(t, tt.wantSeverity, got.Severity)
 			assert.Equal(t, tt.wantManifest, got.Location.File)
-			if tt.name == "CVE name and link" {
-				assert.Equal(t, "Test summary", got.Description)
-				assert.Nil(t, got.Details)
-			}
-			if tt.name == "contextual analysis in reachable detail" {
-				assert.Equal(t, "Details here", got.Description)
-				assert.Nil(t, got.Details)
-			}
-			if tt.name == "non-CVE issue id adds xray identifier" {
-				assert.Empty(t, got.Description)
-				assert.Nil(t, got.Details)
-			}
-			if tt.name == "CVE from issueId when cves slice empty" {
-				assert.Equal(t, "from issue id only", got.Description)
-				assert.Nil(t, got.Details)
-			}
-			if tt.name == "fallback identifier when no CVE or issue id" {
-				assert.Nil(t, got.Details)
-			}
-			if tt.wantSolution != "" {
-				assert.Equal(t, tt.wantSolution, got.Solution)
-			}
+			assert.Equal(t, tt.wantSolution, got.Solution)
+			assert.Nil(t, got.Details)
 			require.Len(t, got.Identifiers, len(tt.identifierTypes))
 			for i, wantType := range tt.identifierTypes {
 				assert.Equal(t, wantType, got.Identifiers[i].Type)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -8,11 +8,14 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
+	"github.com/CycloneDX/cyclonedx-go"
 	"github.com/jfrog/froggit-go/vcsclient"
 	"github.com/jfrog/gofrog/version"
 	"github.com/jfrog/jfrog-cli-core/v2/common/commands"
@@ -29,6 +32,7 @@ import (
 	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
 	"github.com/jfrog/jfrog-client-go/utils/log"
 
+	"github.com/jfrog/frogbot/v2/utils/gitlabreport"
 	"github.com/jfrog/frogbot/v2/utils/issues"
 )
 
@@ -49,7 +53,8 @@ const (
 	skipIndirectVulnerabilitiesMsg = "\n%s is an indirect dependency that will not be updated to version %s.\nFixing indirect dependencies can potentially cause conflicts with other dependencies that depend on the previous version.\nFrogbot skips this to avoid potential incompatibilities and breaking changes."
 	skipBuildToolDependencyMsg     = "Skipping vulnerable package %s since it is not defined in your package descriptor file. " +
 		"Update %s version to %s to fix this vulnerability."
-	JfrogHomeDirEnv = "JFROG_CLI_HOME_DIR"
+	JfrogHomeDirEnv         = "JFROG_CLI_HOME_DIR"
+	cyclonedxOutputFilename = "cyclonedx.json"
 )
 
 var (
@@ -458,4 +463,54 @@ func CreateErrorIfFailUponScannerErrorEnabled(fail bool, messageForLog string, e
 		return nil
 	}
 	return err
+}
+
+func WriteScanResultsToDir(outputDir string, scanResults *results.SecurityCommandResults, startTime time.Time) error {
+	if outputDir == "" {
+		return fmt.Errorf("output directory is required")
+	}
+	if err := os.MkdirAll(outputDir, 0755); err != nil {
+		return fmt.Errorf("create output dir: %w", err)
+	}
+	endTime := time.Now().UTC()
+
+	if err := writeCycloneDxToDir(outputDir, scanResults); err != nil {
+		return fmt.Errorf("write CycloneDX: %w", err)
+	}
+	report, err := gitlabreport.ConvertToGitLabDependencyScanningReport(scanResults, startTime, endTime, FrogbotVersion)
+	if err != nil {
+		return fmt.Errorf("convert to GitLab report: %w", err)
+	}
+	if err = gitlabreport.WriteDependencyScanningReport(outputDir, report); err != nil {
+		return fmt.Errorf("write GitLab report: %w", err)
+	}
+	log.Info(fmt.Sprintf("Scan results written to %s (CycloneDX and GitLab dependency-scanning format)", outputDir))
+	return nil
+}
+
+func writeCycloneDxToDir(outputDir string, scanResults *results.SecurityCommandResults) error {
+	if scanResults == nil {
+		return fmt.Errorf("scan results are required")
+	}
+	fullBom, err := conversion.NewCommandResultsConvertor(conversion.ResultConvertParams{
+		HasViolationContext:    scanResults.HasViolationContext(),
+		IncludeVulnerabilities: scanResults.IncludesVulnerabilities(),
+		IncludeSbom:            true,
+	}).ConvertToCycloneDx(scanResults)
+	if err != nil {
+		return fmt.Errorf("convert to CycloneDX: %w", err)
+	}
+	bom := fullBom.BOM
+	path := filepath.Join(outputDir, cyclonedxOutputFilename)
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("create file: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+	encoder := cyclonedx.NewBOMEncoder(f, cyclonedx.BOMFileFormatJSON)
+	if err = encoder.Encode(&bom); err != nil {
+		return fmt.Errorf("encode CycloneDX: %w", err)
+	}
+	log.Info(fmt.Sprintf("CycloneDX SBOM written to %s", path))
+	return nil
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -502,7 +502,7 @@ func writeCycloneDxToDir(outputDir string, scanResults *results.SecurityCommandR
 	}
 	fullBom, err := conversion.NewCommandResultsConvertor(conversion.ResultConvertParams{
 		HasViolationContext:    scanResults.HasViolationContext(),
-		IncludeVulnerabilities: scanResults.IncludesVulnerabilities(),
+		IncludeVulnerabilities: true,
 		IncludeSbom:            true,
 	}).ConvertToCycloneDx(scanResults)
 	if err != nil {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -15,7 +15,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/CycloneDX/cyclonedx-go"
 	"github.com/jfrog/froggit-go/vcsclient"
 	"github.com/jfrog/gofrog/version"
 	"github.com/jfrog/jfrog-cli-core/v2/common/commands"
@@ -473,7 +472,7 @@ func CreateErrorIfFailUponScannerErrorEnabled(fail bool, messageForLog string, e
 	return err
 }
 
-func WriteScanResultsToDir(outputDir string, scanResults *results.SecurityCommandResults, startTime time.Time) error {
+func WriteScanResultsToGitlabDir(outputDir string, scanResults *results.SecurityCommandResults, startTime time.Time) error {
 	if outputDir == "" {
 		return fmt.Errorf("output directory is required")
 	}
@@ -511,13 +510,7 @@ func writeCycloneDxToDir(outputDir string, scanResults *results.SecurityCommandR
 	bom := fullBom.BOM
 	gitlabreport.EnrichCycloneDXBOMForGitLabReachability(&bom, scanResults)
 	path := filepath.Join(outputDir, cyclonedxOutputFilename)
-	f, err := os.Create(path)
-	if err != nil {
-		return fmt.Errorf("create file: %w", err)
-	}
-	defer func() { _ = f.Close() }()
-	encoder := cyclonedx.NewBOMEncoder(f, cyclonedx.BOMFileFormatJSON)
-	if err = encoder.Encode(&bom); err != nil {
+	if err = utils.SaveCdxContentToFile(path, &bom); err != nil {
 		return fmt.Errorf("encode CycloneDX: %w", err)
 	}
 	log.Info(fmt.Sprintf("CycloneDX SBOM written to %s", path))

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -8,11 +8,14 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
+	"github.com/CycloneDX/cyclonedx-go"
 	"github.com/jfrog/froggit-go/vcsclient"
 	"github.com/jfrog/gofrog/version"
 	"github.com/jfrog/jfrog-cli-core/v2/common/commands"
@@ -29,6 +32,7 @@ import (
 	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
 	"github.com/jfrog/jfrog-client-go/utils/log"
 
+	"github.com/jfrog/frogbot/v2/utils/gitlabreport"
 	"github.com/jfrog/frogbot/v2/utils/issues"
 )
 
@@ -49,7 +53,8 @@ const (
 	skipIndirectVulnerabilitiesMsg = "\n%s is an indirect dependency that will not be updated to version %s.\nFixing indirect dependencies can potentially cause conflicts with other dependencies that depend on the previous version.\nFrogbot skips this to avoid potential incompatibilities and breaking changes."
 	skipBuildToolDependencyMsg     = "Skipping vulnerable package %s since it is not defined in your package descriptor file. " +
 		"Update %s version to %s to fix this vulnerability."
-	JfrogHomeDirEnv = "JFROG_CLI_HOME_DIR"
+	JfrogHomeDirEnv         = "JFROG_CLI_HOME_DIR"
+	cyclonedxOutputFilename = "cyclonedx.json"
 )
 
 var (
@@ -466,4 +471,54 @@ func CreateErrorIfFailUponScannerErrorEnabled(fail bool, messageForLog string, e
 		return nil
 	}
 	return err
+}
+
+func WriteScanResultsToDir(outputDir string, scanResults *results.SecurityCommandResults, startTime time.Time) error {
+	if outputDir == "" {
+		return fmt.Errorf("output directory is required")
+	}
+	if err := os.MkdirAll(outputDir, 0755); err != nil {
+		return fmt.Errorf("create output dir: %w", err)
+	}
+	endTime := time.Now().UTC()
+
+	if err := writeCycloneDxToDir(outputDir, scanResults); err != nil {
+		return fmt.Errorf("write CycloneDX: %w", err)
+	}
+	report, err := gitlabreport.ConvertToGitLabDependencyScanningReport(scanResults, startTime, endTime, FrogbotVersion)
+	if err != nil {
+		return fmt.Errorf("convert to GitLab report: %w", err)
+	}
+	if err = gitlabreport.WriteDependencyScanningReport(outputDir, report); err != nil {
+		return fmt.Errorf("write GitLab report: %w", err)
+	}
+	log.Info(fmt.Sprintf("Scan results written to %s (CycloneDX and GitLab dependency-scanning format)", outputDir))
+	return nil
+}
+
+func writeCycloneDxToDir(outputDir string, scanResults *results.SecurityCommandResults) error {
+	if scanResults == nil {
+		return fmt.Errorf("scan results are required")
+	}
+	fullBom, err := conversion.NewCommandResultsConvertor(conversion.ResultConvertParams{
+		HasViolationContext:    scanResults.HasViolationContext(),
+		IncludeVulnerabilities: scanResults.IncludesVulnerabilities(),
+		IncludeSbom:            true,
+	}).ConvertToCycloneDx(scanResults)
+	if err != nil {
+		return fmt.Errorf("convert to CycloneDX: %w", err)
+	}
+	bom := fullBom.BOM
+	path := filepath.Join(outputDir, cyclonedxOutputFilename)
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("create file: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+	encoder := cyclonedx.NewBOMEncoder(f, cyclonedx.BOMFileFormatJSON)
+	if err = encoder.Encode(&bom); err != nil {
+		return fmt.Errorf("encode CycloneDX: %w", err)
+	}
+	log.Info(fmt.Sprintf("CycloneDX SBOM written to %s", path))
+	return nil
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -509,6 +509,7 @@ func writeCycloneDxToDir(outputDir string, scanResults *results.SecurityCommandR
 		return fmt.Errorf("convert to CycloneDX: %w", err)
 	}
 	bom := fullBom.BOM
+	gitlabreport.EnrichCycloneDXBOMForGitLabReachability(&bom, scanResults)
 	path := filepath.Join(outputDir, cyclonedxOutputFilename)
 	f, err := os.Create(path)
 	if err != nil {

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"encoding/json"
 	"net/http/httptest"
 	"os"
 	"path"
@@ -9,7 +10,6 @@ import (
 	"time"
 
 	"github.com/CycloneDX/cyclonedx-go"
-	"github.com/jfrog/frogbot/v2/utils/outputwriter"
 	"github.com/jfrog/froggit-go/vcsclient"
 	"github.com/jfrog/froggit-go/vcsutils"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
@@ -18,6 +18,9 @@ import (
 	"github.com/jfrog/jfrog-cli-security/utils/results"
 	"github.com/jfrog/jfrog-cli-security/utils/techutils"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/jfrog/frogbot/v2/utils/gitlabreport"
+	"github.com/jfrog/frogbot/v2/utils/outputwriter"
 )
 
 const (
@@ -559,4 +562,76 @@ func createTestSecurityCommandResults() *results.SecurityCommandResults {
 	}
 
 	return scanResults
+}
+
+func TestWriteScanResultsToDir(t *testing.T) {
+	start := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
+
+	tests := []struct {
+		name        string
+		outputDir   func(t *testing.T) string
+		scanResults *results.SecurityCommandResults
+		wantErr     bool
+		errContains string
+		validate    func(t *testing.T, outputDir string)
+	}{
+		{
+			name: "empty output dir",
+			outputDir: func(t *testing.T) string {
+				return ""
+			},
+			scanResults: createTestSecurityCommandResults(),
+			wantErr:     true,
+			errContains: "output directory is required",
+		},
+		{
+			name: "nil scan results",
+			outputDir: func(t *testing.T) string {
+				return t.TempDir()
+			},
+			scanResults: nil,
+			wantErr:     true,
+			errContains: "scan results are required",
+		},
+		{
+			name: "writes CycloneDX and GitLab dependency-scanning report",
+			outputDir: func(t *testing.T) string {
+				return t.TempDir()
+			},
+			scanResults: createTestSecurityCommandResults(),
+			wantErr:     false,
+			validate: func(t *testing.T, outputDir string) {
+				cdxPath := filepath.Join(outputDir, cyclonedxOutputFilename)
+				_, err := os.Stat(cdxPath)
+				assert.NoError(t, err)
+
+				gitlabPath := filepath.Join(outputDir, "gl-dependency-scanning-report.json")
+				data, err := os.ReadFile(gitlabPath)
+				assert.NoError(t, err)
+
+				var report gitlabreport.DependencyScanningReport
+				assert.NoError(t, json.Unmarshal(data, &report))
+				assert.Equal(t, "15.2.4", report.Version)
+				assert.Equal(t, "success", report.Scan.Status)
+				assert.Equal(t, "dependency_scanning", report.Scan.Type)
+				assert.Equal(t, FrogbotVersion, report.Scan.Analyzer.Version)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := tt.outputDir(t)
+			err := WriteScanResultsToDir(dir, tt.scanResults, start)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContains)
+				return
+			}
+			assert.NoError(t, err)
+			if tt.validate != nil {
+				tt.validate(t, dir)
+			}
+		})
+	}
 }

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -564,7 +564,7 @@ func createTestSecurityCommandResults() *results.SecurityCommandResults {
 	return scanResults
 }
 
-func TestWriteScanResultsToDir(t *testing.T) {
+func TestWriteScanResultsToGitlabDir(t *testing.T) {
 	start := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
 
 	tests := []struct {
@@ -622,7 +622,7 @@ func TestWriteScanResultsToDir(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			dir := tt.outputDir(t)
-			err := WriteScanResultsToDir(dir, tt.scanResults, start)
+			err := WriteScanResultsToGitlabDir(dir, tt.scanResults, start)
 			if tt.wantErr {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), tt.errContains)


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/frogbot#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] Update [documentation](https://github.com/jfrog/documentation) about new features / new supported technologies
---

Frogbot can now write scan output to a directory when it runs against GitLab, using the JF_SCAN_RESULTS_OUTPUT_DIR environment variable. The directory gets cyclonedx.json (SBOM) and gl-dependency-scanning-report.json in GitLab’s dependency-scanning format, so pipelines can publish them to GitLab’s security UI. This runs alongside the existing repository scan flow (detection and auto-fix behavior are unchanged when enabled).

<img width="1552" height="771" alt="image" src="https://github.com/user-attachments/assets/0fa7e3bf-8f7b-426d-bbe7-569c32e2558c" />
<img width="1599" height="822" alt="image" src="https://github.com/user-attachments/assets/cc4d0d33-cd29-4279-ac1c-13199b9d6464" />
<img width="1607" height="757" alt="image" src="https://github.com/user-attachments/assets/73e953f7-9dc3-453c-ab9c-f3f2a7b9bb20" />
<img width="797" height="557" alt="image" src="https://github.com/user-attachments/assets/fdab04ee-fdbc-4e0d-bd41-0be6ae9ca6d1" />

