### PR TITLE
Fix Gradle automated dependency updates for multi-module projects

### DIFF
--- a/packageupdaters/commonpackageupdater_test.go
+++ b/packageupdaters/commonpackageupdater_test.go
@@ -525,7 +525,7 @@ func TestGradleFixVulnerabilityIfExists(t *testing.T) {
 
 	gph := GradlePackageUpdater{}
 
-	descriptorFiles, err := gph.GetAllDescriptorFilesFullPaths([]string{groovyDescriptorFileSuffix, kotlinDescriptorFileSuffix})
+	descriptorFiles, err := getAllGradleDescriptorFilesFullPaths()
 	assert.NoError(t, err)
 
 	for _, descriptorFile := range descriptorFiles {
@@ -592,6 +592,49 @@ func TestGradleIsVersionSupportedForFix(t *testing.T) {
 
 	for _, testcase := range testcases {
 		assert.Equal(t, testcase.expectedResult, isVersionSupportedForFix(testcase.impactedVersion))
+	}
+}
+
+func TestGetAllGradleDescriptorFilesFullPaths(t *testing.T) {
+	var testcases = []struct {
+		testProjectRepo        string
+		expectedResultSuffixes []string
+		patternsToExclude      []string
+	}{
+		{
+			testProjectRepo:        "gradle",
+			expectedResultSuffixes: []string{"build.gradle", filepath.Join("innerProjectForTest", "build.gradle.kts")},
+		},
+		{
+			testProjectRepo:        "gradle",
+			expectedResultSuffixes: []string{"build.gradle"},
+			patternsToExclude:      []string{".*innerProjectForTest.*"},
+		},
+	}
+
+	currDir, outerErr := os.Getwd()
+	assert.NoError(t, outerErr)
+
+	for _, testcase := range testcases {
+		tmpDir, err := os.MkdirTemp("", "")
+		assert.NoError(t, err)
+		assert.NoError(t, biutils.CopyDir(filepath.Join("..", "testdata", "projects", testcase.testProjectRepo), tmpDir, true, nil))
+		assert.NoError(t, os.Chdir(tmpDir))
+
+		finalDirPath, err := os.Getwd()
+		assert.NoError(t, err)
+
+		var expectedResults []string
+		for _, suffix := range testcase.expectedResultSuffixes {
+			expectedResults = append(expectedResults, filepath.Join(finalDirPath, suffix))
+		}
+
+		descriptorFilesFullPaths, err := getAllGradleDescriptorFilesFullPaths(testcase.patternsToExclude...)
+		assert.NoError(t, err)
+		assert.ElementsMatch(t, expectedResults, descriptorFilesFullPaths)
+
+		assert.NoError(t, os.Chdir(currDir))
+		assert.NoError(t, fileutils.RemoveTempDir(tmpDir))
 	}
 }
 

--- a/packageupdaters/gradlepackageupdater.go
+++ b/packageupdaters/gradlepackageupdater.go
@@ -2,10 +2,13 @@ package packageupdaters
 
 import (
 	"fmt"
-	"github.com/jfrog/frogbot/v2/utils"
+	"io/fs"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/jfrog/frogbot/v2/utils"
 )
 
 const (
@@ -21,6 +24,12 @@ const (
 var directMapWithVersionRegexp = getMapRegexpEntry("group") + "," + getMapRegexpEntry("name") + "," + getMapRegexpEntry("version")
 
 var gradleDescriptorsSuffixes = []string{groovyDescriptorFileSuffix, kotlinDescriptorFileSuffix}
+
+// skipDirNamesWhenCollectingGradleDescriptors are directory base names to skip when walking for build.gradle / build.gradle.kts (outputs, tooling, VCS).
+var skipDirNamesWhenCollectingGradleDescriptors = map[string]struct{}{
+	".git": {}, ".gradle": {}, "build": {}, "node_modules": {}, "out": {},
+	".idea": {}, "dist": {}, "bin": {}, ".vscode": {},
+}
 
 func getMapRegexpEntry(mapEntry string) string {
 	return fmt.Sprintf(directMapRegexpEntry, mapEntry) + apostrophes + "%s" + apostrophes
@@ -54,7 +63,7 @@ func (gph *GradlePackageUpdater) updateDirectDependency(vulnDetails *utils.Vulne
 	// A gradle project may contain several descriptor files in several sub-modules. Each vulnerability may be found in each of the descriptor files.
 	// Therefore we iterate over every descriptor file for each vulnerability and try to find and fix it.
 	var descriptorFilesFullPaths []string
-	descriptorFilesFullPaths, err = gph.GetAllDescriptorFilesFullPaths(gradleDescriptorsSuffixes)
+	descriptorFilesFullPaths, err = getAllGradleDescriptorFilesFullPaths()
 	if err != nil {
 		return
 	}
@@ -72,6 +81,55 @@ func (gph *GradlePackageUpdater) updateDirectDependency(vulnDetails *utils.Vulne
 
 	if !isAnyDescriptorFileChanged {
 		err = fmt.Errorf("impacted package '%s' was not found or could not be fixed in all descriptor files", vulnDetails.ImpactedDependencyName)
+	}
+	return
+}
+
+// getAllGradleDescriptorFilesFullPaths walks the tree from the current directory and collects all build.gradle / build.gradle.kts files (multi-module projects).
+func getAllGradleDescriptorFilesFullPaths(patternsToExclude ...string) (descriptorFilesFullPaths []string, err error) {
+	var regexpPatternsCompilers []*regexp.Regexp
+	for _, patternToExclude := range patternsToExclude {
+		regexpPatternsCompilers = append(regexpPatternsCompilers, regexp.MustCompile(patternToExclude))
+	}
+
+	err = filepath.WalkDir(".", func(path string, d fs.DirEntry, innerErr error) error {
+		if innerErr != nil {
+			return fmt.Errorf("an error has occurred when attempting to access or traverse the file system: %w", innerErr)
+		}
+
+		if path == "." {
+			return nil
+		}
+
+		for _, regexpCompiler := range regexpPatternsCompilers {
+			if regexpCompiler.FindString(path) != "" {
+				if d.IsDir() {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+		}
+
+		if d.IsDir() {
+			if _, skip := skipDirNamesWhenCollectingGradleDescriptors[filepath.Base(path)]; skip {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		for _, suffix := range gradleDescriptorsSuffixes {
+			if strings.HasSuffix(path, suffix) {
+				absFilePath, absErr := filepath.Abs(path)
+				if absErr != nil {
+					return fmt.Errorf("couldn't retrieve file's absolute path for './%s': %w", path, absErr)
+				}
+				descriptorFilesFullPaths = append(descriptorFilesFullPaths, absFilePath)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		err = fmt.Errorf("failed to get Gradle descriptor files absolute paths: %w", err)
 	}
 	return
 }


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/frogbot#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] Update [documentation](https://github.com/jfrog/documentation) about new features / new supported technologies
---

Frogbot’s Gradle fix path only considered build.gradle / build.gradle.kts files in the repository root. In multi-module Gradle layouts, direct dependencies are often declared only in subproject build files, so fixes failed with errors such as “impacted package … was not found or could not be fixed in all descriptor files” even when those coordinates appeared in a submodule.

This change adds a recursive walk that collects Gradle descriptors across the tree, while skipping common non-source directories (for example .git, .gradle, build, node_modules, IDE folders).