### PR TITLE
Adding Signature Validation When getFrogbot.sh Downloads Frogbot

### DIFF
--- a/buildscripts/getFrogbot.sh
+++ b/buildscripts/getFrogbot.sh
@@ -96,20 +96,101 @@ echoGreetings() {
   echo "Frogbot downloaded successfully!"
 }
 
-getDownloadCommand() {
+download_to() {
+  dl_url="$1"
+  dl_out="$2"
   if [ -n "${REMOTE_PATH}" ]; then
       if [ -n "${JF_ACCESS_TOKEN}" ]; then
-        curl -fLg -H "Authorization:Bearer ${JF_ACCESS_TOKEN}" -X GET "${URL}" -o "${FILE_NAME}"
+        curl -fLg -H "Authorization:Bearer ${JF_ACCESS_TOKEN}" -X GET "${dl_url}" -o "${dl_out}"
       else
-        curl -fLg -u "${JF_USER}:${JF_PASSWORD}" -X GET "${URL}" -o "${FILE_NAME}"
+        curl -fLg -u "${JF_USER}:${JF_PASSWORD}" -X GET "${dl_url}" -o "${dl_out}"
       fi
     else
-      curl -fLg -X GET "${URL}" -o "${FILE_NAME}"
+      curl -fLg -X GET "${dl_url}" -o "${dl_out}"
     fi
 }
 
+download_optional() {
+  dl_url="$1"
+  dl_out="$2"
+  if [ -n "${REMOTE_PATH}" ]; then
+      if [ -n "${JF_ACCESS_TOKEN}" ]; then
+        curl -sfLg -H "Authorization:Bearer ${JF_ACCESS_TOKEN}" -X GET "${dl_url}" -o "${dl_out}" && return 0
+      else
+        curl -sfLg -u "${JF_USER}:${JF_PASSWORD}" -X GET "${dl_url}" -o "${dl_out}" && return 0
+      fi
+    else
+      curl -sfLg -X GET "${dl_url}" -o "${dl_out}" && return 0
+    fi
+  return 1
+}
+
+verify_checksum() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum -c "${FILE_NAME}.sha256"
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 -c "${FILE_NAME}.sha256"
+  else
+    echo "Neither sha256sum nor shasum was found; cannot verify the binary checksum." >&2
+    return 1
+  fi
+}
+
+verify_checksum_or_exit() {
+  if [ "${FROGBOT_INSECURE_SKIP_CHECKSUM_VERIFICATION:-}" = "1" ]; then
+    echo "WARNING: skipping checksum verification (FROGBOT_INSECURE_SKIP_CHECKSUM_VERIFICATION=1)." >&2
+    return 0
+  fi
+  checksum_url="${URL}.sha256"
+  if ! download_to "${checksum_url}" "${FILE_NAME}.sha256"; then
+    echo "Failed to download the checksum file for this Frogbot build." >&2
+    echo "Releases that predate checksum publishing require FROGBOT_INSECURE_SKIP_CHECKSUM_VERIFICATION=1 (not recommended)." >&2
+    rm -f "${FILE_NAME}"
+    exit 1
+  fi
+  if ! verify_checksum; then
+    echo "Checksum verification failed." >&2
+    rm -f "${FILE_NAME}" "${FILE_NAME}.sha256"
+    exit 1
+  fi
+  rm -f "${FILE_NAME}.sha256"
+}
+
+verify_gpg_if_signature_present() {
+  sig_url="${URL}.asc"
+  if ! download_optional "${sig_url}" "${FILE_NAME}.asc"; then
+    rm -f "${FILE_NAME}.asc"
+    return 0
+  fi
+  key_url="${PLATFORM_URL}/artifactory/${REMOTE_PATH}frogbot/v3/${VERSION}/frogbot-signing-key.asc"
+  if ! download_optional "${key_url}" "frogbot-signing-key.asc"; then
+    echo "A detached signature was published but frogbot-signing-key.asc could not be downloaded for this release." >&2
+    rm -f "${FILE_NAME}" "${FILE_NAME}.asc"
+    exit 1
+  fi
+  if ! command -v gpg >/dev/null 2>&1; then
+    echo "gpg is required to verify the Frogbot release signature." >&2
+    rm -f "${FILE_NAME}" "${FILE_NAME}.asc" "frogbot-signing-key.asc"
+    exit 1
+  fi
+  GNUPGHOME=$(mktemp -d "${TMPDIR:-/tmp}/frogbot-gpg.XXXXXX")
+  export GNUPGHOME
+  gpg --batch --import "frogbot-signing-key.asc" >/dev/null 2>&1
+  if ! gpg --batch --verify "${FILE_NAME}.asc" "${FILE_NAME}"; then
+    echo "GPG signature verification failed." >&2
+    rm -rf "${GNUPGHOME}"
+    rm -f "${FILE_NAME}" "${FILE_NAME}.asc" "frogbot-signing-key.asc"
+    exit 1
+  fi
+  rm -rf "${GNUPGHOME}"
+  rm -f "${FILE_NAME}.asc" "frogbot-signing-key.asc"
+}
+
 download() {
-  getDownloadCommand && setPermissions && echoGreetings
+  download_to "${URL}" "${FILE_NAME}" || { rm -f "${FILE_NAME}"; exit 1; }
+  verify_checksum_or_exit
+  verify_gpg_if_signature_present
+  setPermissions && echoGreetings
 }
 
 setFrogbotVersion "$@"

--- a/buildscripts/getFrogbot.sh
+++ b/buildscripts/getFrogbot.sh
@@ -110,86 +110,94 @@ download_to() {
     fi
 }
 
-download_optional() {
+head_request() {
   dl_url="$1"
-  dl_out="$2"
   if [ -n "${REMOTE_PATH}" ]; then
       if [ -n "${JF_ACCESS_TOKEN}" ]; then
-        curl -sfLg -H "Authorization:Bearer ${JF_ACCESS_TOKEN}" -X GET "${dl_url}" -o "${dl_out}" && return 0
+        curl -sfILg -H "Authorization:Bearer ${JF_ACCESS_TOKEN}" "${dl_url}"
       else
-        curl -sfLg -u "${JF_USER}:${JF_PASSWORD}" -X GET "${dl_url}" -o "${dl_out}" && return 0
+        curl -sfILg -u "${JF_USER}:${JF_PASSWORD}" "${dl_url}"
       fi
     else
-      curl -sfLg -X GET "${dl_url}" -o "${dl_out}" && return 0
+      curl -sfILg "${dl_url}"
     fi
-  return 1
 }
 
-verify_checksum() {
-  if command -v sha256sum >/dev/null 2>&1; then
-    sha256sum -c "${FILE_NAME}.sha256"
-  elif command -v shasum >/dev/null 2>&1; then
-    shasum -a 256 -c "${FILE_NAME}.sha256"
+get_header_value() {
+  header_name="$1"
+  echo "$2" | awk -v header="$header_name" '
+    BEGIN { IGNORECASE=1; value="" }
+    $1 ~ header":" { sub(/^[^:]+:[[:space:]]*/, ""); value=$0 }
+    END { gsub(/\r/, "", value); print value }
+  '
+}
+
+local_md5() {
+  if command -v md5sum >/dev/null 2>&1; then
+    md5sum "$1" | awk '{print $1}'
   else
-    echo "Neither sha256sum nor shasum was found; cannot verify the binary checksum." >&2
-    return 1
+    md5 -q "$1"
   fi
 }
 
-verify_checksum_or_exit() {
+local_sha1() {
+  if command -v sha1sum >/dev/null 2>&1; then
+    sha1sum "$1" | awk '{print $1}'
+  else
+    shasum -a 1 "$1" | awk '{print $1}'
+  fi
+}
+
+local_sha256() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
+verify_download_or_exit() {
   if [ "${FROGBOT_INSECURE_SKIP_CHECKSUM_VERIFICATION:-}" = "1" ]; then
     echo "WARNING: skipping checksum verification (FROGBOT_INSECURE_SKIP_CHECKSUM_VERIFICATION=1)." >&2
+    echo "Downloaded ${FILE_NAME} (checksum verification skipped)."
     return 0
   fi
-  checksum_url="${URL}.sha256"
-  if ! download_to "${checksum_url}" "${FILE_NAME}.sha256"; then
-    echo "Failed to download the checksum file for this Frogbot build." >&2
-    echo "Releases that predate checksum publishing require FROGBOT_INSECURE_SKIP_CHECKSUM_VERIFICATION=1 (not recommended)." >&2
+
+  headers=$(head_request "${URL}") || {
+    echo "Failed to fetch Artifactory file details for this Frogbot build." >&2
+    rm -f "${FILE_NAME}"
+    exit 1
+  }
+
+  remote_md5=$(get_header_value "X-Checksum-Md5" "${headers}")
+  remote_sha1=$(get_header_value "X-Checksum-Sha1" "${headers}")
+  remote_sha256=$(get_header_value "X-Checksum-Sha256" "${headers}")
+
+  if [ -z "${remote_md5}" ] || [ -z "${remote_sha1}" ]; then
+    echo "Artifactory did not return checksum headers; cannot verify the downloaded binary." >&2
     rm -f "${FILE_NAME}"
     exit 1
   fi
-  if ! verify_checksum; then
-    echo "Checksum verification failed." >&2
-    rm -f "${FILE_NAME}" "${FILE_NAME}.sha256"
-    exit 1
-  fi
-  rm -f "${FILE_NAME}.sha256"
-}
 
-verify_gpg_if_signature_present() {
-  sig_url="${URL}.asc"
-  if ! download_optional "${sig_url}" "${FILE_NAME}.asc"; then
-    rm -f "${FILE_NAME}.asc"
-    return 0
-  fi
-  key_url="${PLATFORM_URL}/artifactory/${REMOTE_PATH}frogbot/v3/${VERSION}/frogbot-signing-key.asc"
-  if ! download_optional "${key_url}" "frogbot-signing-key.asc"; then
-    echo "A detached signature was published but frogbot-signing-key.asc could not be downloaded for this release." >&2
-    rm -f "${FILE_NAME}" "${FILE_NAME}.asc"
+  file_md5=$(local_md5 "${FILE_NAME}")
+  file_sha1=$(local_sha1 "${FILE_NAME}")
+  file_sha256=$(local_sha256 "${FILE_NAME}")
+  if [ "${file_md5}" != "${remote_md5}" ] || [ "${file_sha1}" != "${remote_sha1}" ] \
+    || { [ -n "${remote_sha256}" ] && [ "${file_sha256}" != "${remote_sha256}" ]; }; then
+    echo "Checksum verification failed." >&2
+    echo "Remote md5=${remote_md5} sha1=${remote_sha1} sha256=${remote_sha256}" >&2
+    echo "Local  md5=${file_md5} sha1=${file_sha1} sha256=${file_sha256}" >&2
+    rm -f "${FILE_NAME}"
     exit 1
   fi
-  if ! command -v gpg >/dev/null 2>&1; then
-    echo "gpg is required to verify the Frogbot release signature." >&2
-    rm -f "${FILE_NAME}" "${FILE_NAME}.asc" "frogbot-signing-key.asc"
-    exit 1
-  fi
-  GNUPGHOME=$(mktemp -d "${TMPDIR:-/tmp}/frogbot-gpg.XXXXXX")
-  export GNUPGHOME
-  gpg --batch --import "frogbot-signing-key.asc" >/dev/null 2>&1
-  if ! gpg --batch --verify "${FILE_NAME}.asc" "${FILE_NAME}"; then
-    echo "GPG signature verification failed." >&2
-    rm -rf "${GNUPGHOME}"
-    rm -f "${FILE_NAME}" "${FILE_NAME}.asc" "frogbot-signing-key.asc"
-    exit 1
-  fi
-  rm -rf "${GNUPGHOME}"
-  rm -f "${FILE_NAME}.asc" "frogbot-signing-key.asc"
+
+  echo "Checksum verification passed for ${FILE_NAME}."
 }
 
 download() {
+  echo "Downloading from ${URL} ..."
   download_to "${URL}" "${FILE_NAME}" || { rm -f "${FILE_NAME}"; exit 1; }
-  verify_checksum_or_exit
-  verify_gpg_if_signature_present
+  verify_download_or_exit
   setPermissions && echoGreetings
 }
 

--- a/buildscripts/verifyArtifact.sh
+++ b/buildscripts/verifyArtifact.sh
@@ -1,0 +1,187 @@
+#!/bin/bash
+# Verifies a local file against Artifactory checksum headers from a HEAD request
+
+verifyArtifact_get_header_value() {
+  local header_name="$1"
+  local headers="$2"
+  echo "${headers}" | awk -v header="${header_name}" '
+    BEGIN { IGNORECASE=1; value="" }
+    $1 ~ header":" { sub(/^[^:]+:[[:space:]]*/, ""); value=$0 }
+    END { gsub(/\r/, "", value); print value }
+  '
+}
+
+verifyArtifact_local_md5() {
+  if command -v md5sum >/dev/null 2>&1; then
+    md5sum "$1" | awk '{print $1}'
+  else
+    md5 -q "$1"
+  fi
+}
+
+verifyArtifact_local_sha1() {
+  if command -v sha1sum >/dev/null 2>&1; then
+    sha1sum "$1" | awk '{print $1}'
+  else
+    shasum -a 1 "$1" | awk '{print $1}'
+  fi
+}
+
+verifyArtifact_local_sha256() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
+# HEAD via curl; uses JF_ACCESS_TOKEN, JF_USER/JF_PASSWORD, or no auth.
+verifyArtifact_head_request_curl() {
+  local dl_url="$1"
+  if [[ -n "${JF_ACCESS_TOKEN:-}" ]]; then
+    curl -sfILg -H "Authorization:Bearer ${JF_ACCESS_TOKEN}" "${dl_url}"
+  elif [[ -n "${JF_USER:-}" ]]; then
+    curl -sfILg -u "${JF_USER}:${JF_PASSWORD:-}" "${dl_url}"
+  else
+    curl -sfILg "${dl_url}"
+  fi
+}
+
+# HEAD via JFrog CLI (uses configured server credentials from jf c).
+verifyArtifact_head_request_jf() {
+  local repo_path="$1"
+  repo_path="${repo_path#/}"
+  jf rt curl -X HEAD -sI "/${repo_path}"
+}
+
+verifyArtifact_compare_checksums() {
+  local local_file="$1"
+  local headers="$2"
+
+  local remote_md5 remote_sha1 remote_sha256
+  local file_md5 file_sha1 file_sha256
+
+  remote_md5=$(verifyArtifact_get_header_value "X-Checksum-Md5" "${headers}")
+  remote_sha1=$(verifyArtifact_get_header_value "X-Checksum-Sha1" "${headers}")
+  remote_sha256=$(verifyArtifact_get_header_value "X-Checksum-Sha256" "${headers}")
+
+  if [[ -z "${remote_md5}" || -z "${remote_sha1}" ]]; then
+    echo "Artifactory did not return checksum headers; cannot verify ${local_file}." >&2
+    return 1
+  fi
+
+  file_md5=$(verifyArtifact_local_md5 "${local_file}")
+  file_sha1=$(verifyArtifact_local_sha1 "${local_file}")
+  file_sha256=$(verifyArtifact_local_sha256 "${local_file}")
+  if [[ "${file_md5}" != "${remote_md5}" || "${file_sha1}" != "${remote_sha1}" ]] \
+    || { [[ -n "${remote_sha256}" ]] && [[ "${file_sha256}" != "${remote_sha256}" ]]; }; then
+    echo "Checksum verification failed for ${local_file}." >&2
+    echo "Remote md5=${remote_md5} sha1=${remote_sha1} sha256=${remote_sha256}" >&2
+    echo "Local  md5=${file_md5} sha1=${file_sha1} sha256=${file_sha256}" >&2
+    return 1
+  fi
+
+  return 0
+}
+
+# Verifies local file against remote Artifactory artifact.
+# Usage:
+#   verifyArtifact.sh --file <path> --url <full-artifactory-url>
+#   verifyArtifact.sh --file <path> --repo-path <repo/path> --jf-cli
+verifyArtifact_file() {
+  local local_file=""
+  local artifact_url=""
+  local repo_path=""
+  local use_jf_cli=0
+  local on_failure=""
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --file)
+        local_file="$2"
+        shift 2
+        ;;
+      --url)
+        artifact_url="$2"
+        shift 2
+        ;;
+      --repo-path)
+        repo_path="$2"
+        shift 2
+        ;;
+      --jf-cli)
+        use_jf_cli=1
+        shift
+        ;;
+      --on-failure)
+        on_failure="$2"
+        shift 2
+        ;;
+      *)
+        echo "Unknown argument: $1" >&2
+        return 1
+        ;;
+    esac
+  done
+
+  if [[ -z "${local_file}" ]]; then
+    echo "--file is required." >&2
+    return 1
+  fi
+  if [[ ! -f "${local_file}" ]]; then
+    echo "Local file not found: ${local_file}" >&2
+    return 1
+  fi
+
+  if [[ "${FROGBOT_INSECURE_SKIP_CHECKSUM_VERIFICATION:-}" = "1" ]]; then
+    echo "WARNING: skipping checksum verification (FROGBOT_INSECURE_SKIP_CHECKSUM_VERIFICATION=1)." >&2
+    echo "Skipped checksum verification for ${local_file}."
+    return 0
+  fi
+
+  local headers=""
+  if [[ "${use_jf_cli}" -eq 1 ]]; then
+    if [[ -z "${repo_path}" ]]; then
+      echo "--repo-path is required with --jf-cli." >&2
+      return 1
+    fi
+    if ! headers=$(verifyArtifact_head_request_jf "${repo_path}"); then
+      echo "Failed to fetch Artifactory file details for /${repo_path#/}." >&2
+      [[ -n "${on_failure}" ]] && rm -f "${on_failure}"
+      return 1
+    fi
+  else
+    if [[ -z "${artifact_url}" ]]; then
+      echo "--url is required unless --jf-cli is set." >&2
+      return 1
+    fi
+    if ! headers=$(verifyArtifact_head_request_curl "${artifact_url}"); then
+      echo "Failed to fetch Artifactory file details for ${artifact_url}." >&2
+      [[ -n "${on_failure}" ]] && rm -f "${on_failure}"
+      return 1
+    fi
+  fi
+
+  if ! verifyArtifact_compare_checksums "${local_file}" "${headers}"; then
+    [[ -n "${on_failure}" ]] && rm -f "${on_failure}"
+    return 1
+  fi
+
+  if [[ "${use_jf_cli}" -eq 1 ]]; then
+    echo "Checksum verification passed for ${local_file} (repo path: /${repo_path#/})."
+  else
+    echo "Checksum verification passed for ${local_file}."
+  fi
+  return 0
+}
+
+verifyArtifact_main() {
+  set -euo pipefail
+  if ! verifyArtifact_file "$@"; then
+    exit 1
+  fi
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  verifyArtifact_main "$@"
+fi

--- a/release/buildAndUpload.sh
+++ b/release/buildAndUpload.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+set -eu
+
+build () {
+  pkg="$1"
+  export GOOS="$2"
+  export GOARCH="$3"
+  exeName="$4"
+  echo "Building $exeName for $GOOS-$GOARCH ..."
+
+  CGO_ENABLED=0 jf go build -o "$exeName" -ldflags '-w -extldflags "-static" -X github.com/jfrog/frogbot/v3/utils.FrogbotVersion='"$version"
+  chmod +x "$exeName"
+
+  if [[ "$pkg" = "frogbot-linux-386" ]]; then
+    verifyVersionMatching
+  fi
+}
+
+buildAndUpload () {
+  pkg="$1"
+  goos="$2"
+  goarch="$3"
+  fileExtension="$4"
+  exeName="frogbot$fileExtension"
+
+  build "$pkg" "$goos" "$goarch" "$exeName"
+
+  destPath="$pkgPath/$version/$pkg/$exeName"
+  echo "Uploading $exeName to $destPath ..."
+  jf rt u "./$exeName" "$destPath"
+  sha256sum "$exeName" >"${exeName}.sha256"
+  jf rt u "./${exeName}.sha256" "$pkgPath/$version/$pkg/${exeName}.sha256"
+  rm -f "./${exeName}.sha256"
+  if [[ -n "${FROGBOT_GPG_KEY_ID:-}" ]] && command -v gpg >/dev/null 2>&1; then
+    gpg --batch --yes --local-user "$FROGBOT_GPG_KEY_ID" --detach-sign --armor -o "${exeName}.asc" "./$exeName"
+    jf rt u "./${exeName}.asc" "$pkgPath/$version/$pkg/${exeName}.asc"
+    rm -f "./${exeName}.asc"
+  fi
+}
+
+upload_signing_public_key() {
+  if [[ -n "${FROGBOT_GPG_PUBLIC_KEY_FILE:-}" ]] && [[ -f "${FROGBOT_GPG_PUBLIC_KEY_FILE}" ]]; then
+    jf rt u "${FROGBOT_GPG_PUBLIC_KEY_FILE}" "$pkgPath/$version/frogbot-signing-key.asc"
+  fi
+}
+
+verifyVersionMatching () {
+  echo "Verifying provided version matches built version..."
+  res=$(eval "./frogbot -v")
+  exitCode=$?
+  if [[ $exitCode -ne 0 ]]; then
+    echo "Error: Failed verifying version matches"
+    exit $exitCode
+  fi
+
+  echo "Output: $res"
+  builtVersion="${res##* }"
+  if [[ "$builtVersion" != "$version" ]]; then
+    echo "Versions dont match. Provided: $version, Actual: $builtVersion"
+    exit 1
+  fi
+  echo "Versions match."
+}
+
+version="$1"
+pkgPath="ecosys-frogbot/v3"
+
+buildAndUpload 'frogbot-linux-386' 'linux' '386' ''
+buildAndUpload 'frogbot-linux-amd64' 'linux' 'amd64' ''
+buildAndUpload 'frogbot-linux-s390x' 'linux' 's390x' ''
+buildAndUpload 'frogbot-linux-arm64' 'linux' 'arm64' ''
+buildAndUpload 'frogbot-linux-arm' 'linux' 'arm' ''
+buildAndUpload 'frogbot-linux-ppc64' 'linux' 'ppc64' ''
+buildAndUpload 'frogbot-linux-ppc64le' 'linux' 'ppc64le' ''
+buildAndUpload 'frogbot-mac-386' 'darwin' 'amd64' ''
+buildAndUpload 'frogbot-mac-arm64' 'darwin' 'arm64' ''
+buildAndUpload 'frogbot-windows-amd64' 'windows' 'amd64' '.exe'
+
+upload_signing_public_key
+jf rt u "./buildscripts/getFrogbot.sh" "$pkgPath/$version/" --flat

--- a/release/buildAndUpload.sh
+++ b/release/buildAndUpload.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 set -eu
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/../buildscripts/verifyArtifact.sh"
+
+JF_SERVER_ID="${JF_SERVER_ID:-}"
+
+#function build(pkg, goos, goarch, exeName)
 build () {
   pkg="$1"
   export GOOS="$2"
@@ -10,12 +17,16 @@ build () {
 
   CGO_ENABLED=0 jf go build -o "$exeName" -ldflags '-w -extldflags "-static" -X github.com/jfrog/frogbot/v3/utils.FrogbotVersion='"$version"
   chmod +x "$exeName"
-
-  if [[ "$pkg" = "frogbot-linux-386" ]]; then
-    verifyVersionMatching
-  fi
 }
 
+verify_upload() {
+  local localFile="$1"
+  local destPath="$2"
+  echo "Verifying uploaded artifact ${localFile} using Artifactory file details ..."
+  verifyArtifact_file --file "${localFile}" --repo-path "${destPath}" --jf-cli
+}
+
+#function buildAndUpload(pkg, goos, goarch, fileExtension)
 buildAndUpload () {
   pkg="$1"
   goos="$2"
@@ -28,22 +39,10 @@ buildAndUpload () {
   destPath="$pkgPath/$version/$pkg/$exeName"
   echo "Uploading $exeName to $destPath ..."
   jf rt u "./$exeName" "$destPath"
-  sha256sum "$exeName" >"${exeName}.sha256"
-  jf rt u "./${exeName}.sha256" "$pkgPath/$version/$pkg/${exeName}.sha256"
-  rm -f "./${exeName}.sha256"
-  if [[ -n "${FROGBOT_GPG_KEY_ID:-}" ]] && command -v gpg >/dev/null 2>&1; then
-    gpg --batch --yes --local-user "$FROGBOT_GPG_KEY_ID" --detach-sign --armor -o "${exeName}.asc" "./$exeName"
-    jf rt u "./${exeName}.asc" "$pkgPath/$version/$pkg/${exeName}.asc"
-    rm -f "./${exeName}.asc"
-  fi
+  verify_upload "./$exeName" "$destPath"
 }
 
-upload_signing_public_key() {
-  if [[ -n "${FROGBOT_GPG_PUBLIC_KEY_FILE:-}" ]] && [[ -f "${FROGBOT_GPG_PUBLIC_KEY_FILE}" ]]; then
-    jf rt u "${FROGBOT_GPG_PUBLIC_KEY_FILE}" "$pkgPath/$version/frogbot-signing-key.asc"
-  fi
-}
-
+# Verify version provided in pipelines UI matches version in frogbot source code.
 verifyVersionMatching () {
   echo "Verifying provided version matches built version..."
   res=$(eval "./frogbot -v")
@@ -76,5 +75,4 @@ buildAndUpload 'frogbot-mac-386' 'darwin' 'amd64' ''
 buildAndUpload 'frogbot-mac-arm64' 'darwin' 'arm64' ''
 buildAndUpload 'frogbot-windows-amd64' 'windows' 'amd64' '.exe'
 
-upload_signing_public_key
 jf rt u "./buildscripts/getFrogbot.sh" "$pkgPath/$version/" --flat


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/frogbot#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] Update [documentation](https://github.com/jfrog/documentation) about new features / new supported technologies
---

Add Artifactory checksum verification for Frogbot release artifacts using GetRemoteFileDetails, so uploaded and downloaded binaries are validated against server-side MD5/SHA1/SHA256 headers.

