### PR TITLE
Fix git push and remote operations failing on non-HTTPS remote URLs 

### DIFF
--- a/utils/git.go
+++ b/utils/git.go
@@ -343,10 +343,10 @@ func (gm *GitManager) BranchExistsInRemote(branchName string) (bool, error) {
 	if gm.dryRun {
 		return false, nil
 	}
-	remote, err := gm.localGitRepository.Remote(gm.remoteName)
-	if err != nil {
-		return false, errorutils.CheckError(err)
-	}
+	remote := git.NewRemote(gm.localGitRepository.Storer, &config.RemoteConfig{
+		Name: gm.remoteName,
+		URLs: []string{gm.remoteGitUrl},
+	})
 	refList, err := remote.List(&git.ListOptions{Auth: gm.auth})
 	if err != nil {
 		return false, errorutils.CheckError(err)
@@ -361,10 +361,10 @@ func (gm *GitManager) BranchExistsInRemote(branchName string) (bool, error) {
 }
 
 func (gm *GitManager) RemoveRemoteBranch(branchName string) error {
-	remote, err := gm.localGitRepository.Remote(gm.remoteName)
-	if err != nil {
-		return err
-	}
+	remote := git.NewRemote(gm.localGitRepository.Storer, &config.RemoteConfig{
+		Name: gm.remoteName,
+		URLs: []string{gm.remoteGitUrl},
+	})
 	return remote.Push(&git.PushOptions{
 		Auth:     gm.auth,
 		RefSpecs: []config.RefSpec{config.RefSpec(":refs/heads/" + branchName)},
@@ -379,6 +379,7 @@ func (gm *GitManager) Push(force bool, branchName string) error {
 	}
 	if err := gm.localGitRepository.Push(&git.PushOptions{
 		RemoteName: gm.remoteName,
+		RemoteURL:  gm.remoteGitUrl,
 		Auth:       gm.auth,
 		Force:      force,
 		RefSpecs:   []config.RefSpec{config.RefSpec(fmt.Sprintf(refFormat, branchName))},


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/frogbot#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] Update [documentation](https://github.com/jfrog/documentation) about new features / new supported technologies
---

 Fix git operations failing when .git/config remote URL is not HTTPS                                                                                                                                     
                                                                                                                                                                                                        
Push, BranchExistsInRemote, and RemoveRemoteBranch all resolved the remote URL by reading from .git/config via the remote name. This works when the repo was cloned over HTTPS, but fails in two scenarios:
                                                                                                                                                                                                          
1. Bitbucket Pipelines CI — the pipeline agent overwrites the remote URL to an internal proxy URL (http://bitbucket.org/...) before the user script runs. go-git bypasses the pipeline's git proxy, so pushing to that URL directly fails with "authentication required".
2. SSH-cloned repos — when a repo is cloned via SSH, .git/config stores a git@... URL. go-git detects SSH transport, sees HTTP auth credentials, and returns ErrInvalidAuthMethod. (SSH is not supported in Frogbot but this is a start for it)               
                                                                                                                                                                                                          
GitManager already has remoteGitUrl which is guaranteed to be HTTPS — SetRemoteGitUrl explicitly normalizes any non-HTTPS URL to the HTTPS URL returned by the VCS provider API. Fetch was already using RemoteURL: gm.remoteGitUrl correctly; Push, BranchExistsInRemote, and RemoveRemoteBranch inconsistently were not.                                                                                      
                                                                                                                                                                                                          
The fix makes all three use gm.remoteGitUrl for the actual network connection, consistent with how Fetch already works.

All tests are passing in fork (failing here due to a change that needs to be merged to master)
<img width="346" height="667" alt="Screenshot 2026-05-17 at 13 31 22" src="https://github.com/user-attachments/assets/c30820ac-4867-401d-96d7-b165b509ddf1" />
