### PR TITLE
Fix nil pointer dereference in getTotalFindingsFromScanResults V3

### DIFF
--- a/scanrepository/scanrepository.go
+++ b/scanrepository/scanrepository.go
@@ -176,6 +176,10 @@ func (sr *ScanRepositoryCmd) scanAndFixBranch(repository *utils.Repository) (tot
 }
 
 func getTotalFindingsFromScanResults(scanResults *results.SecurityCommandResults) int {
+	if scanResults == nil {
+		return 0
+	}
+
 	summary, err := conversion.NewCommandResultsConvertor(conversion.ResultConvertParams{IncludeVulnerabilities: scanResults.IncludesVulnerabilities(), HasViolationContext: scanResults.HasViolationContext()}).ConvertToSummary(scanResults)
 	if err != nil {
 		log.Error("Failed to extract findings summary from scan results:", err)


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/frogbot#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] Update [documentation](https://github.com/jfrog/documentation) about new features / new supported technologies
---
from fork:
<img width="365" height="661" alt="Screenshot 2026-05-17 at 17 59 53" src="https://github.com/user-attachments/assets/c5d28736-1dfc-42cf-afc1-ae17cfa91422" />

