### PR TITLE
fix: skip credentials for public releases.jfrog.io downloads

### DIFF
--- a/buildscripts/getFrogbot.sh
+++ b/buildscripts/getFrogbot.sh
@@ -106,9 +106,12 @@ echoGreetings() {
 download_to() {
   dl_url="$1"
   dl_out="$2"
-  if [ -n "${JF_ACCESS_TOKEN:-}" ]; then
+  # Only use credentials when downloading from the user's own Artifactory
+  # (REMOTE_PATH is set when JF_RELEASES_REPO is configured).
+  # Public releases.jfrog.io downloads must not send user credentials.
+  if [ -n "${REMOTE_PATH:-}" ] && [ -n "${JF_ACCESS_TOKEN:-}" ]; then
     curl -fLg -H "Authorization:Bearer ${JF_ACCESS_TOKEN}" -X GET "${dl_url}" -o "${dl_out}"
-  elif [ -n "${JF_USER:-}" ]; then
+  elif [ -n "${REMOTE_PATH:-}" ] && [ -n "${JF_USER:-}" ]; then
     curl -fLg -u "${JF_USER}:${JF_PASSWORD:-}" -X GET "${dl_url}" -o "${dl_out}"
   else
     curl -fLg -X GET "${dl_url}" -o "${dl_out}"
@@ -117,9 +120,10 @@ download_to() {
 
 head_request() {
   dl_url="$1"
-  if [ -n "${JF_ACCESS_TOKEN:-}" ]; then
+  # Only use credentials when targeting the user's own Artifactory.
+  if [ -n "${REMOTE_PATH:-}" ] && [ -n "${JF_ACCESS_TOKEN:-}" ]; then
     curl -sfILg -H "Authorization:Bearer ${JF_ACCESS_TOKEN}" "${dl_url}"
-  elif [ -n "${JF_USER:-}" ]; then
+  elif [ -n "${REMOTE_PATH:-}" ] && [ -n "${JF_USER:-}" ]; then
     curl -sfILg -u "${JF_USER}:${JF_PASSWORD:-}" "${dl_url}"
   else
     curl -sfILg "${dl_url}"
@@ -142,9 +146,10 @@ artifact_url_to_storage_url() {
 
 storage_request() {
   local storage_url="$1"
-  if [ -n "${JF_ACCESS_TOKEN:-}" ]; then
+  # Only use credentials when targeting the user's own Artifactory.
+  if [ -n "${REMOTE_PATH:-}" ] && [ -n "${JF_ACCESS_TOKEN:-}" ]; then
     curl -sfLg -H "Authorization:Bearer ${JF_ACCESS_TOKEN}" "${storage_url}"
-  elif [ -n "${JF_USER:-}" ]; then
+  elif [ -n "${REMOTE_PATH:-}" ] && [ -n "${JF_USER:-}" ]; then
     curl -sfLg -u "${JF_USER}:${JF_PASSWORD:-}" "${storage_url}"
   else
     curl -sfLg "${storage_url}"


### PR DESCRIPTION
## Problem

`download_to()`, `head_request()`, and `storage_request()` unconditionally use `JF_ACCESS_TOKEN` / `JF_USER` credentials when set — even when downloading from the public `releases.jfrog.io` server.

This breaks the use case where a user has their own Artifactory credentials configured (`JF_URL` + `JF_USER` + `JF_PASSWORD`) but is **not** using `JF_RELEASES_REPO`. The script sends those credentials to `releases.jfrog.io`, which returns 401 because the user doesn't exist there.

Fixes #1339

## Fix

Guard all three HTTP helper functions with a `REMOTE_PATH` check. Credentials are only sent when `JF_RELEASES_REPO` is configured (which sets `REMOTE_PATH`), meaning the URL points to the user's own Artifactory instance. When downloading from the public server, no credentials are sent.

### Before
```bash
# Always used credentials when set, even for public URLs
if [ -n "${JF_ACCESS_TOKEN:-}" ]; then
    curl -fLg -H "Authorization:Bearer ..." ...
```

### After
```bash
# Only use credentials when downloading from user's own Artifactory
if [ -n "${REMOTE_PATH:-}" ] && [ -n "${JF_ACCESS_TOKEN:-}" ]; then
    curl -fLg -H "Authorization:Bearer ..." ...
```

### Affected functions
- `download_to()` — binary download
- `head_request()` — HEAD for checksum headers
- `storage_request()` — Artifactory Storage API fallback

## Behavior matrix

| Scenario | `REMOTE_PATH` | Credentials used? |
|---|---|---|
| Public download (no `JF_RELEASES_REPO`) | empty | ❌ No |
| Private Artifactory (`JF_RELEASES_REPO` set) | set | ✅ Yes |
| No credentials at all | empty | ❌ No (unchanged) |