### PR TITLE
Keep all JF_SAST* env vars when sanitizing JF env

### DIFF
--- a/utils/getconfiguration.go
+++ b/utils/getconfiguration.go
@@ -483,7 +483,7 @@ func extractVcsProviderFromEnv() (vcsutils.VcsProvider, error) {
 func SanitizeEnv() error {
 	for _, env := range os.Environ() {
 		// We leave JF_SAST_DEFAULT_SCAN_MODE as this must be populated as env var to the Sast scanner
-		if !strings.HasPrefix(env, "JF_") || strings.Contains(env, "JF_SAST_DEFAULT_SCAN_MODE") {
+		if !strings.HasPrefix(env, "JF_") || strings.HasPrefix(env, "JF_SAST") {
 			continue
 		}
 		envSplit := strings.Split(env, "=")

--- a/utils/getconfiguration.go
+++ b/utils/getconfiguration.go
@@ -482,7 +482,8 @@ func extractVcsProviderFromEnv() (vcsutils.VcsProvider, error) {
 
 func SanitizeEnv() error {
 	for _, env := range os.Environ() {
-		if !strings.HasPrefix(env, "JF_") {
+		// We leave JF_SAST_DEFAULT_SCAN_MODE as this must be populated as env var to the Sast scanner
+		if !strings.HasPrefix(env, "JF_") || strings.Contains(env, "JF_SAST_DEFAULT_SCAN_MODE") {
 			continue
 		}
 		envSplit := strings.Split(env, "=")


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/frogbot#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] Update [documentation](https://github.com/jfrog/documentation) about new features / new supported technologies
---

This env var is required to be kept to enable new Sast scanner mode that required getting its value through this env var