### PR TITLE
Fix in getFrogbot.sh - Use credentials only when REMOTE_PATH is set

### DIFF
--- a/buildscripts/getFrogbot.sh
+++ b/buildscripts/getFrogbot.sh
@@ -106,10 +106,12 @@ echoGreetings() {
 download_to() {
   dl_url="$1"
   dl_out="$2"
-  if [ -n "${JF_ACCESS_TOKEN:-}" ]; then
-    curl -fLg -H "Authorization:Bearer ${JF_ACCESS_TOKEN}" -X GET "${dl_url}" -o "${dl_out}"
-  elif [ -n "${JF_USER:-}" ]; then
-    curl -fLg -u "${JF_USER}:${JF_PASSWORD:-}" -X GET "${dl_url}" -o "${dl_out}"
+  if [ -n "${REMOTE_PATH}" ]; then
+    if [ -n "${JF_ACCESS_TOKEN:-}" ]; then
+      curl -fLg -H "Authorization:Bearer ${JF_ACCESS_TOKEN}" -X GET "${dl_url}" -o "${dl_out}"
+    else
+      curl -fLg -u "${JF_USER}:${JF_PASSWORD:-}" -X GET "${dl_url}" -o "${dl_out}"
+    fi
   else
     curl -fLg -X GET "${dl_url}" -o "${dl_out}"
   fi
@@ -117,10 +119,12 @@ download_to() {
 
 head_request() {
   dl_url="$1"
-  if [ -n "${JF_ACCESS_TOKEN:-}" ]; then
-    curl -sfILg -H "Authorization:Bearer ${JF_ACCESS_TOKEN}" "${dl_url}"
-  elif [ -n "${JF_USER:-}" ]; then
-    curl -sfILg -u "${JF_USER}:${JF_PASSWORD:-}" "${dl_url}"
+  if [ -n "${REMOTE_PATH}" ]; then
+    if [ -n "${JF_ACCESS_TOKEN:-}" ]; then
+      curl -sfILg -H "Authorization:Bearer ${JF_ACCESS_TOKEN}" "${dl_url}"
+    else
+      curl -sfILg -u "${JF_USER}:${JF_PASSWORD:-}" "${dl_url}"
+    fi
   else
     curl -sfILg "${dl_url}"
   fi
@@ -142,10 +146,12 @@ artifact_url_to_storage_url() {
 
 storage_request() {
   local storage_url="$1"
-  if [ -n "${JF_ACCESS_TOKEN:-}" ]; then
-    curl -sfLg -H "Authorization:Bearer ${JF_ACCESS_TOKEN}" "${storage_url}"
-  elif [ -n "${JF_USER:-}" ]; then
-    curl -sfLg -u "${JF_USER}:${JF_PASSWORD:-}" "${storage_url}"
+  if [ -n "${REMOTE_PATH}" ]; then
+    if [ -n "${JF_ACCESS_TOKEN:-}" ]; then
+      curl -sfLg -H "Authorization:Bearer ${JF_ACCESS_TOKEN}" "${storage_url}"
+    else
+      curl -sfLg -u "${JF_USER}:${JF_PASSWORD:-}" "${storage_url}"
+    fi
   else
     curl -sfLg "${storage_url}"
   fi


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/frogbot#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] Update [documentation](https://github.com/jfrog/documentation) about new features / new supported technologies
---

Minimal fix in buildscripts/getFrogbot.sh: credentials are only used when REMOTE_PATH is set (i.e. when JF_RELEASES_REPO is configured).

Updated: download_to, head_request, storage_request

Behavior:

No JF_RELEASES_REPO → download/checksum calls to releases.jfrog.io are anonymous (no JF_ACCESS_TOKEN / JF_USER).
JF_RELEASES_REPO set → same as before: Bearer token or basic auth against the customer’s JF_URL.
This restores the pre–2.34.0 / v3.1.x pattern and addresses both customer 401 reports. dash -n still passes.