### PR TITLE
Fix Go module path separators in remediation commands

### DIFF
--- a/packagehandlers/gopackagehandler.go
+++ b/packagehandlers/gopackagehandler.go
@@ -1,6 +1,8 @@
 package packagehandlers
 
 import (
+	"strings"
+
 	"github.com/jfrog/frogbot/v2/utils"
 	golangutils "github.com/jfrog/jfrog-cli-artifactory/artifactory/commands/golang"
 )
@@ -17,5 +19,11 @@ func (golang *GoPackageHandler) UpdateDependency(vulnDetails *utils.Vulnerabilit
 		}
 	}
 	// In Golang, we can address every dependency as a direct dependency.
-	return golang.CommonPackageHandler.UpdateDependency(vulnDetails, vulnDetails.Technology.GetPackageInstallationCommand())
+	normalizedVulnDetails := *vulnDetails
+	normalizedVulnDetails.ImpactedDependencyName = normalizeGoModulePath(vulnDetails.ImpactedDependencyName)
+	return golang.CommonPackageHandler.UpdateDependency(&normalizedVulnDetails, vulnDetails.Technology.GetPackageInstallationCommand())
+}
+
+func normalizeGoModulePath(packageName string) string {
+	return strings.ReplaceAll(packageName, ":", "/")
 }

--- a/packagehandlers/packagehandlers_test.go
+++ b/packagehandlers/packagehandlers_test.go
@@ -395,6 +395,36 @@ func TestUpdateDependency(t *testing.T) {
 	}
 }
 
+func TestNormalizeGoModulePath(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "keeps slash-separated module path",
+			input:    "go.opentelemetry.io/otel/sdk",
+			expected: "go.opentelemetry.io/otel/sdk",
+		},
+		{
+			name:     "converts colon-separated module path",
+			input:    "go.opentelemetry.io:otel:sdk",
+			expected: "go.opentelemetry.io/otel/sdk",
+		},
+		{
+			name:     "converts github module path",
+			input:    "github.com:golang:go",
+			expected: "github.com/golang/go",
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, normalizeGoModulePath(test.input))
+		})
+	}
+}
+
 func TestPipPackageRegex(t *testing.T) {
 	var pipPackagesRegexTests = []pipPackageRegexTest{
 		{"oslo.config", "oslo.config>=1.12.1,<1.13"},


### PR DESCRIPTION
Summary:
- Normalize Go module names reported with colon separators before building the `go get` remediation command.
- Keep the normalization scoped to Go package updates so Maven-style coordinates are not affected.
- Add coverage for slash-separated and colon-separated Go module paths.

- [ ] All [tests](https://github.com/jfrog/frogbot#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
- [x] I used gofmt for formatting the code before submitting the pull request.
- [ ] Update [documentation](https://github.com/jfrog/documentation) about new features / new supported technologies
---

Verification:
- `gofmt -w packagehandlers\gopackagehandler.go packagehandlers\packagehandlers_test.go`
- `go test ./packagehandlers -run TestNormalizeGoModulePath -count=1`
- `go test ./packagehandlers -run "TestNormalizeGoModulePath|TestUpdateDependency" -count=1` was also tried, but `TestUpdateDependency` requires `JF_URL` in this local environment.

Docs note: this is a bug fix for existing Go remediation behavior, not a new feature or new supported technology.

This was implemented with Codex assistance, with the final diff manually reviewed and kept focused on issue #1243.
