### PR TITLE
Add nil guard when audit fails when fixing vuln

### DIFF
--- a/scanrepository/scanrepository.go
+++ b/scanrepository/scanrepository.go
@@ -161,11 +161,6 @@ func (sr *ScanRepositoryCmd) scanAndFixBranch(repository *utils.Repository) (tot
 		log.Info(fmt.Sprintf("This command is running in detection mode only. To enable automatic fixing of issues, set the '%s' flag under the repository's configuration settings in Jfrog platform", createAutoFixPrConfigNameInProfile))
 		return totalFindings, nil
 	}
-	if scanResults == nil {
-		log.Info("No scan results found")
-		return totalFindings, nil
-	}
-
 	vulnerabilitiesByPathMap, err := sr.createVulnerabilitiesMap(repository.GeneralConfig.FailUponAnyScannerError, scanResults)
 	if err != nil {
 		if err = utils.CreateErrorIfFailUponScannerErrorEnabled(repository.GeneralConfig.FailUponAnyScannerError, fmt.Sprintf("An error occurred while preparing the vulnerabilities map for branch '%s'.", sr.scanDetails.BaseBranch()), err); err != nil {
@@ -502,6 +497,10 @@ func (sr *ScanRepositoryCmd) switchToTempWorkingDir() (tempWd string, restoreDir
 
 // Create a vulnerabilities map - a map with 'impacted package' as a key and all the necessary information of this vulnerability as value.
 func (sr *ScanRepositoryCmd) createVulnerabilitiesMap(failUponError bool, scanResults *results.SecurityCommandResults) (map[string]*utils.VulnerabilityDetails, error) {
+	if scanResults == nil {
+		log.Info("No scan results found")
+		return nil, nil
+	}
 	vulnerabilitiesMap := map[string]*utils.VulnerabilityDetails{}
 	simpleJsonResult, err := conversion.NewCommandResultsConvertor(conversion.ResultConvertParams{IncludeVulnerabilities: scanResults.IncludesVulnerabilities(), HasViolationContext: scanResults.HasViolationContext()}).ConvertToSimpleJson(scanResults)
 	if err != nil {

--- a/scanrepository/scanrepository.go
+++ b/scanrepository/scanrepository.go
@@ -161,6 +161,10 @@ func (sr *ScanRepositoryCmd) scanAndFixBranch(repository *utils.Repository) (tot
 		log.Info(fmt.Sprintf("This command is running in detection mode only. To enable automatic fixing of issues, set the '%s' flag under the repository's configuration settings in Jfrog platform", createAutoFixPrConfigNameInProfile))
 		return totalFindings, nil
 	}
+	if scanResults == nil {
+		log.Info("No scan results found")
+		return totalFindings, nil
+	}
 
 	vulnerabilitiesByPathMap, err := sr.createVulnerabilitiesMap(repository.GeneralConfig.FailUponAnyScannerError, scanResults)
 	if err != nil {

--- a/scanrepository/scanrepository_test.go
+++ b/scanrepository/scanrepository_test.go
@@ -487,6 +487,11 @@ func TestCreateVulnerabilitiesMap(t *testing.T) {
 		expectedMap map[string]*utils.VulnerabilityDetails
 	}{
 		{
+			name:        "No results",
+			scanResults: nil,
+			expectedMap: map[string]*utils.VulnerabilityDetails{},
+		},
+		{
 			name: "Scan results with no violations and vulnerabilities",
 			scanResults: &results.SecurityCommandResults{Targets: []*results.TargetResults{{
 				ScanTarget: results.ScanTarget{Target: "target1"},
@@ -636,6 +641,116 @@ func loadTestSBOM(t *testing.T, filename string) *cyclonedx.BOM {
 	decoder := cyclonedx.NewBOMDecoder(f, cyclonedx.BOMFileFormatJSON)
 	require.NoError(t, decoder.Decode(bom))
 	return bom
+}
+
+func TestGetTotalFindingsFromScanResults(t *testing.T) {
+	testCases := []struct {
+		name          string
+		scanResults   *results.SecurityCommandResults
+		expectedCount int
+	}{
+		{
+			name:          "Nil scan results",
+			scanResults:   nil,
+			expectedCount: 0,
+		},
+		{
+			name: "No violations or vulnerabilities",
+			scanResults: &results.SecurityCommandResults{Targets: []*results.TargetResults{{
+				ScanTarget: results.ScanTarget{Target: "target1"},
+			}}},
+			expectedCount: 0,
+		},
+		{
+			name: "Vulnerabilities only",
+			scanResults: &results.SecurityCommandResults{
+				ResultsMetaData: results.ResultsMetaData{
+					ResultContext: results.ResultContext{IncludeVulnerabilities: true}},
+				Targets: []*results.TargetResults{{
+					ScanTarget: results.ScanTarget{Target: "target1", Technologies: []techutils.Technology{techutils.Npm}},
+					ScaResults: &results.ScaScanResults{
+						Sbom: loadTestSBOM(t, "sbom_with_vulnerabilities.json"),
+					},
+				}},
+			},
+			expectedCount: 4,
+		},
+		{
+			name: "Violations only",
+			scanResults: &results.SecurityCommandResults{
+				ResultsMetaData: results.ResultsMetaData{
+					ResultContext: results.ResultContext{Watches: []string{"w1"}}},
+				Targets: []*results.TargetResults{{
+					ScanTarget: results.ScanTarget{Target: "target1", Technologies: []techutils.Technology{techutils.Npm}},
+				}},
+				Violations: &violationutils.Violations{
+					Sca: []violationutils.CveViolation{
+						{
+							ScaViolation: violationutils.ScaViolation{
+								ImpactedComponent: cyclonedx.Component{
+									BOMRef:     "pkg:npm/viol1@1.0.0",
+									PackageURL: "pkg:npm/viol1@1.0.0",
+								},
+							},
+							CveVulnerability: cyclonedx.Vulnerability{BOMRef: "CVE-2023-1234"},
+						},
+						{
+							ScaViolation: violationutils.ScaViolation{
+								ImpactedComponent: cyclonedx.Component{
+									BOMRef:     "pkg:npm/viol2@2.0.0",
+									PackageURL: "pkg:npm/viol2@2.0.0",
+								},
+							},
+							CveVulnerability: cyclonedx.Vulnerability{BOMRef: "CVE-2022-1234"},
+						},
+					},
+				},
+			},
+			expectedCount: 2,
+		},
+		{
+			name: "Violations take precedence over vulnerabilities",
+			scanResults: &results.SecurityCommandResults{
+				ResultsMetaData: results.ResultsMetaData{
+					ResultContext: results.ResultContext{IncludeVulnerabilities: true, Watches: []string{"w1"}}},
+				Targets: []*results.TargetResults{{
+					ScanTarget: results.ScanTarget{Target: "target1", Technologies: []techutils.Technology{techutils.Npm}},
+					ScaResults: &results.ScaScanResults{
+						Sbom: loadTestSBOM(t, "sbom_with_vulnerabilities.json"),
+					},
+				}},
+				Violations: &violationutils.Violations{
+					Sca: []violationutils.CveViolation{
+						{
+							ScaViolation: violationutils.ScaViolation{
+								ImpactedComponent: cyclonedx.Component{
+									BOMRef:     "pkg:npm/viol1@1.0.0",
+									PackageURL: "pkg:npm/viol1@1.0.0",
+								},
+							},
+							CveVulnerability: cyclonedx.Vulnerability{BOMRef: "CVE-2023-1234"},
+						},
+						{
+							ScaViolation: violationutils.ScaViolation{
+								ImpactedComponent: cyclonedx.Component{
+									BOMRef:     "pkg:npm/viol2@2.0.0",
+									PackageURL: "pkg:npm/viol2@2.0.0",
+								},
+							},
+							CveVulnerability: cyclonedx.Vulnerability{BOMRef: "CVE-2022-1234"},
+						},
+					},
+				},
+			},
+			expectedCount: 2,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			assert.Equal(t, testCase.expectedCount, getTotalFindingsFromScanResults(testCase.scanResults))
+		})
+	}
 }
 
 // Verifies unsupported packages return specific error


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/frogbot#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] Update [documentation](https://github.com/jfrog/documentation) about new features / new supported technologies
---

## `Fix panic when Audit failed and configure to fail on any error`

when `FailUponAnyScannerError=true` in the scan and audit fail:

```
2026-06-11T10:15:13.7070841Z 10:15:13 [Warn] An error occurred during Audit execution for 'main' branch. Fixes will be skipped for this branch
```

we get:
```
2026-06-11T10:15:13.7866231Z panic: runtime error: invalid memory address or nil pointer dereference
2026-06-11T10:15:13.7866968Z [signal 0xc0000005 code=0x0 addr=0x60 pc=0x7ff606316fca]
2026-06-11T10:15:13.7867209Z 
2026-06-11T10:15:13.7867916Z goroutine 1 [running]:
2026-06-11T10:15:13.7868821Z github.com/jfrog/jfrog-cli-security/utils/results.(*SecurityCommandResults).IncludesVulnerabilities(...)
2026-06-11T10:15:13.7869524Z         /Users/erant/go/pkg/mod/github.com/jfrog/jfrog-cli-security@v1.29.3/utils/results/results.go:523
2026-06-11T10:15:13.7870135Z github.com/jfrog/frogbot/v3/scanrepository.(*ScanRepositoryCmd).createVulnerabilitiesMap(0xda85bff8240, 0x0, 0x0)
2026-06-11T10:15:13.7870778Z         /Users/erant/Desktop/jfrog/frogbot/scanrepository/scanrepository.go:502 +0x4a
2026-06-11T10:15:13.7871395Z github.com/jfrog/frogbot/v3/scanrepository.(*ScanRepositoryCmd).scanAndFixBranch(0xda85bff8240, 0xda85c2a1508)
2026-06-11T10:15:13.7872062Z         /Users/erant/Desktop/jfrog/frogbot/scanrepository/scanrepository.go:165 +0x1aa
2026-06-11T10:15:13.7872739Z github.com/jfrog/frogbot/v3/scanrepository.(*ScanRepositoryCmd).prepareEnvAndScanBranch(0xda85bff8240, 0xda85c2a1508)
2026-06-11T10:15:13.7873333Z         /Users/erant/Desktop/jfrog/frogbot/scanrepository/scanrepository.go:112 +0x1e9
```