### PR TITLE
Handle config profiles with 0 modules gracefully

### DIFF
--- a/utils/getconfiguration.go
+++ b/utils/getconfiguration.go
@@ -538,12 +538,20 @@ func validateConfigProfile(configProfile *services.ConfigProfile) error {
 		return errors.New("received a nil config profile")
 	}
 
-	if len(configProfile.Modules) != 1 {
-		return fmt.Errorf("%s config profile returned with %d modules. A profile must have exactly 1 module", configProfile.ProfileName, len(configProfile.Modules))
+	if len(configProfile.Modules) == 0 {
+		log.Warn(fmt.Sprintf("%s config profile returned with 0 modules. Using default module", configProfile.ProfileName))
+		configProfile.Modules = createDefaultConfig()
+	}
+	if len(configProfile.Modules) > 1 {
+		log.Warn(fmt.Sprintf("%s config profile returned with %d modules. Only the first module will be used", configProfile.ProfileName, len(configProfile.Modules)))
 	}
 
 	if configProfile.Modules[0].PathFromRoot != "." {
 		return fmt.Errorf("the module in the config profile should be associated with the root of the repository. Expected pathFromRoot to be '.' but received '%s'", configProfile.Modules[0].PathFromRoot)
 	}
 	return nil
+}
+
+func createDefaultConfig() []services.Module {
+	return []services.Module{{PathFromRoot: ".", ScanConfig: services.ScanConfig{ScaScannerConfig: services.ScaScannerConfig{EnableScaScan: true}}}}
 }


### PR DESCRIPTION
Instead of erroring when a profile has 0 modules, log a warning and inject a default SCA-only module so scanning can proceed. When a profile has 2+ modules, log a warning and continue with the first module.

- [ ] All [tests](https://github.com/jfrog/frogbot#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] Update [documentation](https://github.com/jfrog/documentation) about new features / new supported technologies
---

