### PR TITLE
Log audit errors when fail_upon_any_scanner_error is disabled

### DIFF
--- a/scanrepository/scanrepository.go
+++ b/scanrepository/scanrepository.go
@@ -248,7 +248,7 @@ func (sr *ScanRepositoryCmd) fixVulnerablePackages(repository *utils.Repository,
 		}
 	}
 	if err != nil {
-		return utils.CreateErrorIfFailUponScannerErrorEnabled(repository.GeneralConfig.FailUponAnyScannerError, fmt.Sprintf("failed to fix vulnerable dependencies: %s", err.Error()), err)
+		return utils.CreateErrorIfFailUponScannerErrorEnabled(repository.GeneralConfig.FailUponAnyScannerError, "failed to fix vulnerable dependencies", err)
 	}
 	return nil
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -466,7 +466,7 @@ func isUrlAccessible(url string) bool {
 // If not - instead of returning an error we log the error and continue as if we didn't have an error
 func CreateErrorIfFailUponScannerErrorEnabled(fail bool, messageForLog string, err error) error {
 	if !fail {
-		log.Warn(messageForLog)
+		log.Warn(fmt.Sprintf("%s: %s", messageForLog, err))
 		return nil
 	}
 	return err

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -466,7 +466,7 @@ func isUrlAccessible(url string) bool {
 // If not - instead of returning an error we log the error and continue as if we didn't have an error
 func CreateErrorIfFailUponScannerErrorEnabled(fail bool, messageForLog string, err error) error {
 	if !fail {
-		log.Warn(fmt.Sprintf("%s: %s", messageForLog, err))
+		log.Warn(fmt.Sprintf("%s: %v", messageForLog, err))
 		return nil
 	}
 	return err


### PR DESCRIPTION
## Summary

When `fail_upon_any_scanner_error` is off, frogbot skips failing the command but previously logged only a generic warning, hiding the underlying audit error. Include the actual error in the warning so pipelines that allow partial results remain debuggable without toggling the config profile.

## Test plan

- [x] Run `scan-repository` with a profile where `fail_upon_any_scanner_error` is false and audit fails; confirm the warn line includes the scanner error text and exit code stays 0.

Made with [Cursor](https://cursor.com)