### PR TITLE
Log audit errors when partial results are allowed (v2 backport)

### DIFF
--- a/scanrepository/scanrepository.go
+++ b/scanrepository/scanrepository.go
@@ -291,7 +291,7 @@ func (cfp *ScanRepositoryCmd) fixVulnerablePackages(repository *utils.Repository
 		err = cfp.fixIssuesSeparatePRs(repository, vulnerabilitiesByWdMap)
 	}
 	if err != nil {
-		return utils.CreateErrorIfPartialResultsDisabled(cfp.scanDetails.AllowPartialResults(), fmt.Sprintf("failed to fix vulnerable dependencies: %s", err.Error()), err)
+		return utils.CreateErrorIfPartialResultsDisabled(cfp.scanDetails.AllowPartialResults(), "failed to fix vulnerable dependencies", err)
 	}
 	return
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -585,7 +585,7 @@ func isUrlAccessible(url string) bool {
 // This function checks if partial results are allowed by the user. If so instead of returning an error we log the error and continue as if we didn't have an error
 func CreateErrorIfPartialResultsDisabled(allowPartial bool, messageForLog string, err error) error {
 	if allowPartial {
-		log.Warn(messageForLog)
+		log.Warn(fmt.Sprintf("%s: %v", messageForLog, err))
 		return nil
 	}
 	return err


### PR DESCRIPTION
## Summary
- Backport of #1352 to `master` (v2)
- When partial results are allowed (`allow_partial_results` / `FailUponAnyScannerError` disabled), include the underlying scanner error in the warn log instead of only a generic message
- Avoid double-logging fix errors by not embedding `err` in the message at the fix-vulnerabilities call site

## Test plan
- [ ] Run `scan-repository` with partial results allowed and a failing audit; confirm the warn line includes the scanner error text and exit code stays 0
- [ ] Run with partial results disabled; confirm behavior is unchanged (command fails on scanner error)


Made with [Cursor](https://cursor.com)