### PR TITLE
Switch Archive Download to Git Clone in scan-pr

### DIFF
--- a/scanpullrequest/scanpullrequest.go
+++ b/scanpullrequest/scanpullrequest.go
@@ -116,7 +116,9 @@ func downloadSourceAndTarget(repoConfig *utils.Repository, scanDetails *utils.Sc
 	cleanup = func() error { return errors.Join(cleanupSource(), cleanupTarget()) }
 
 	log.Info("Downloading source branch code...")
-	if sourceBranchWd, cleanupSource, err = utils.DownloadRepoToTempDir(scanDetails.Client(),
+	if sourceBranchWd, cleanupSource, err = utils.CloneRepoToTempDir(scanDetails.Client(),
+		scanDetails.Username,
+		scanDetails.Token,
 		scanDetails.PullRequestDetails.Source.Owner,
 		scanDetails.PullRequestDetails.Source.Repository,
 		scanDetails.PullRequestDetails.Source.Name,
@@ -125,7 +127,7 @@ func downloadSourceAndTarget(repoConfig *utils.Repository, scanDetails *utils.Sc
 		return
 	}
 	target := repoConfig.Params.Git.PullRequestDetails.Target
-	if targetBranchWd, cleanupTarget, err = utils.DownloadRepoToTempDir(scanDetails.Client(), target.Owner, target.Repository, target.Name); err != nil {
+	if targetBranchWd, cleanupTarget, err = utils.CloneRepoToTempDir(scanDetails.Client(), scanDetails.Username, scanDetails.Token, target.Owner, target.Repository, target.Name); err != nil {
 		err = fmt.Errorf("failed to download target branch code. Error: %s", err.Error())
 		return
 	}

--- a/utils/git.go
+++ b/utils/git.go
@@ -82,6 +82,11 @@ func (gm *GitManager) SetAuth(username, token string) *GitManager {
 	return gm
 }
 
+func (gm *GitManager) SetUrl(remoteHttpsGitUrl string) *GitManager {
+	gm.remoteGitUrl = remoteHttpsGitUrl
+	return gm
+}
+
 func (gm *GitManager) SetRemoteGitUrl(remoteHttpsGitUrl string) (*GitManager, error) {
 	// Check if the .git directory exists
 	dotGitExists, err := fileutils.IsDirExists(git.GitDirName, false)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -275,7 +275,7 @@ func CloneRepoToTempDir(client vcsclient.VcsClient, username, token, repoOwner, 
 		err = fmt.Errorf("failed to clone branch: <%s/%s/%s> with error: %s", repoOwner, repoName, branch, err.Error())
 		return
 	}
-	log.Debug("Repository clone completed.")
+	log.Debug("Repository clone completed")
 	return
 }
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -275,7 +275,7 @@ func CloneRepoToTempDir(client vcsclient.VcsClient, username, token, repoOwner, 
 		err = fmt.Errorf("failed to clone branch: <%s/%s/%s> with error: %s", repoOwner, repoName, branch, err.Error())
 		return
 	}
-	log.Debug("Repository clone completed")
+	log.Debug("Repository clone completed.")
 	return
 }
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -257,7 +257,7 @@ func GenerateFrogbotSarifReport(extendedResults *results.SecurityCommandResults)
 	return stringReport, hasRuns, err
 }
 
-func DownloadRepoToTempDir(client vcsclient.VcsClient, repoOwner, repoName, branch string) (wd string, cleanup func() error, err error) {
+func CloneRepoToTempDir(client vcsclient.VcsClient, username, token, repoOwner, repoName, branch string) (wd string, cleanup func() error, err error) {
 	wd, err = fileutils.CreateTempDir()
 	if err != nil {
 		return
@@ -265,12 +265,17 @@ func DownloadRepoToTempDir(client vcsclient.VcsClient, repoOwner, repoName, bran
 	cleanup = func() error {
 		return fileutils.RemoveTempDir(wd)
 	}
-	log.Debug(fmt.Sprintf("Downloading <%s/%s/%s> to: '%s'", repoOwner, repoName, branch, wd))
-	if err = client.DownloadRepository(context.Background(), repoOwner, repoName, branch, wd); err != nil {
-		err = fmt.Errorf("failed to download branch: <%s/%s/%s> with error: %s", repoOwner, repoName, branch, err.Error())
+	repoInfo, err := client.GetRepositoryInfo(context.Background(), repoOwner, repoName)
+	if err != nil {
+		err = fmt.Errorf("failed to get repository info for <%s/%s>: %s", repoOwner, repoName, err.Error())
 		return
 	}
-	log.Debug("Repository download completed")
+	log.Debug(fmt.Sprintf("Cloning <%s/%s/%s> to: '%s'", repoOwner, repoName, branch, wd))
+	if err = NewGitManager().SetAuth(username, token).SetUrl(repoInfo.CloneInfo.HTTP).Clone(wd, branch); err != nil {
+		err = fmt.Errorf("failed to clone branch: <%s/%s/%s> with error: %s", repoOwner, repoName, branch, err.Error())
+		return
+	}
+	log.Debug("Repository clone completed")
 	return
 }
 


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/frogbot#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] Update [documentation](https://github.com/jfrog/documentation) about new features / new supported technologies
---

A customer had an issue where the scan failed in a Gradle project scan, because the downloaded repo (archive download) did not contain .git dir. 
Gradle evaluates all build.gradle scripts during its configuration phase, before reaching generateDepTrees. One of the scripts required a .git dir which does not exist in an archive download.
The fix is simple - switching the usage of archive download with git clone.
This is a bit slower but fixes the issue easily.