### PR TITLE
XRAY-145620 - Distinguish zero-module config profile errors (v2)

### DIFF
--- a/utils/params.go
+++ b/utils/params.go
@@ -923,7 +923,7 @@ func getConfigProfileIfExistsAndValid(xrayVersion string, jfrogServer *coreconfi
 func verifyConfigProfileValidity(configProfile *services.ConfigProfile) (err error) {
 	// Currently, only a single Module that represents the entire project is supported
 	if len(configProfile.Modules) != 1 {
-		err = fmt.Errorf("more than one module was found '%s' profile. Frogbot currently supports only one module per config profile", configProfile.ProfileName)
+		err = fmt.Errorf("expected exactly 1 module in '%s' profile, found %d. Frogbot currently supports only one module per config profile", configProfile.ProfileName, len(configProfile.Modules))
 		return
 	}
 	if configProfile.Modules[0].PathFromRoot != "." {


### PR DESCRIPTION
## Summary

v2 maintenance cherry-pick of the same error-message fix as [frogbot#1368](https://github.com/jfrog/frogbot/pull/1368).

`verifyConfigProfileValidity` now reports `found %d` instead of the misleading `more than one module` text when a centralized config profile has **0 modules** ([XRAY-145620](https://jfrog-int.atlassian.net/browse/XRAY-145620)).

**Base:** `v2_main` · Companion: [JFROG/xray#20535](https://github.jfrog.info/JFROG/xray/pull/20535)

## Test plan

- [x] `go build .`