### PR TITLE
Fix verifyArtifact.sh script

### DIFF
--- a/buildscripts/verifyArtifact.sh
+++ b/buildscripts/verifyArtifact.sh
@@ -59,7 +59,7 @@ verifyArtifact_storage_request_jf() {
   repo_path="${repo_path#/}"
   local repo="${repo_path%%/*}"
   local path="${repo_path#*/}"
-  jf rt curl -s "/api/storage/${repo}/${path}"
+  jf rt curl "/api/storage/${repo}/${path}" -s
 }
 
 verifyArtifact_artifact_url_to_storage_url() {


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/frogbot#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] Update [documentation](https://github.com/jfrog/documentation) about new features / new supported technologies
---
 verifyArtifact.sh's Artifactory Storage API fallback (verifyArtifact_storage_request_jf) crashed with:
  [Error] Could not find argument in curl command.

  Cause: the call was written as:
  jf rt curl -s "/api/storage/${repo}/${path}"
  jf rt curl's argument parser scans for the first non-flag argument to treat as the request URL. For a bare 2-character flag like -s, it assumes the value lives in the next argument — even though -s
  (curl's silent flag) takes no value. So it swallowed the URL as -s's value, leaving no argument to find, and errored out.

  This fallback is only reached when the HEAD-based checksum lookup doesn't return checksum headers (which can legitimately happen depending on the Artifactory/proxy setup) — so it silently broke the
  verification safety net whenever that path was exercised.

  Fix

  Put the URL before the flag so it's matched as the argument before the parser reaches -s:
  jf rt curl "/api/storage/${repo}/${path}" -s
  No behavior change to the actual request — curl doesn't care about flag/URL order.

