### PR TITLE
XRAY-145620 - Align config profile module-count error message (v3)

### DIFF
--- a/utils/getconfiguration.go
+++ b/utils/getconfiguration.go
@@ -539,7 +539,7 @@ func validateConfigProfile(configProfile *services.ConfigProfile) error {
 	}
 
 	if len(configProfile.Modules) != 1 {
-		return fmt.Errorf("%s config profile returned with %d modules. A profile must have exactly 1 module", configProfile.ProfileName, len(configProfile.Modules))
+		return fmt.Errorf("expected exactly 1 module in '%s' profile, found %d. Frogbot currently supports only one module per config profile", configProfile.ProfileName, len(configProfile.Modules))
 	}
 
 	if configProfile.Modules[0].PathFromRoot != "." {

--- a/utils/getconfiguration_test.go
+++ b/utils/getconfiguration_test.go
@@ -383,7 +383,7 @@ func TestValidateConfigProfile(t *testing.T) {
 				ProfileName: "my-profile",
 				Modules:     []services.Module{},
 			},
-			expectedError: "my-profile config profile returned with 0 modules. A profile must have exactly 1 module",
+			expectedError: "expected exactly 1 module in 'my-profile' profile, found 0. Frogbot currently supports only one module per config profile",
 		},
 		{
 			name: "Multiple modules",
@@ -394,7 +394,7 @@ func TestValidateConfigProfile(t *testing.T) {
 					{ModuleName: "module-2", PathFromRoot: "subdir"},
 				},
 			},
-			expectedError: "my-profile config profile returned with 2 modules. A profile must have exactly 1 module",
+			expectedError: "expected exactly 1 module in 'my-profile' profile, found 2. Frogbot currently supports only one module per config profile",
 		},
 		{
 			name: "Module path not at root",


### PR DESCRIPTION
## Summary

Aligns Frogbot v3 config profile validation with v2 ([#1369](https://github.com/jfrog/frogbot/pull/1369)) and jfrog-cli-security ([#793](https://github.com/jfrog/jfrog-cli-security/pull/793)).

`main` already reported module count; this changes the wording to:

`expected exactly 1 module in '<profile>' profile, found <n>`

so zero-module cases (XRAY-145620 theft symptom) are obvious in logs.

## Test plan

- [x] `TestValidateConfigProfile` expectations updated

Made with [Cursor](https://cursor.com)