### PR TITLE
XRAY-155957 - Print the violation link in the failing-policy logs

### DIFF
--- a/scanpullrequest/scanpullrequest.go
+++ b/scanpullrequest/scanpullrequest.go
@@ -57,7 +57,7 @@ func (pr *ScanPullRequestCmd) Run(repository utils.Repository, client vcsclient.
 		return
 	}
 	if pullRequestIssues.IsFailPrRuleApplied() {
-		issues.LogFailingPolicyRulesForPr(pullRequestIssues.Violations)
+		issues.LogFailingPolicyRulesForPr(pullRequestIssues.Violations, &repository.Server, repository.Params.JFrogPlatform.XrayVersion)
 		err = errors.New(SecurityIssueFoundErr)
 		return
 	}

--- a/scanrepository/scanrepository.go
+++ b/scanrepository/scanrepository.go
@@ -160,7 +160,7 @@ func (sr *ScanRepositoryCmd) scanAndFixBranch(repository *utils.Repository) (tot
 	defer func() {
 		// Always check policy even if an error occurred during the scan
 		if policyErr := policy.CheckPolicyFailBuildError(scanResults); policyErr != nil {
-			issues.LogFailingPolicyRulesForBuild(scanResults.Violations)
+			issues.LogFailingPolicyRulesForBuild(scanResults.Violations, &repository.Server, repository.Params.JFrogPlatform.XrayVersion)
 			err = errors.Join(err, policyErr)
 		}
 	}()

--- a/testdata/logfailingrules/fail_build_results.txt
+++ b/testdata/logfailingrules/fail_build_results.txt
@@ -1,19 +1,25 @@
 The following findings triggered a policy rule configured to fail the build:
   - CVE-2026-4800 (lodash@4.17.20)
+      Violation: https://myserver.com/ui/violations/2074859048208711680
       Triggered:
         - Watch: 'security-watch', Policy: 'critical-cves', Rule: 'block-critical-severity'
   - License: GPL-3.0-only (requests@2.25.1)
+      Violation: https://myserver.com/ui/violations/2074859048464564224
       Triggered:
         - Watch: 'license-watch', Policy: 'banned-licenses', Rule: 'block-copyleft'
   - Operational Risk: EOL (old-lib@0.1.0)
+      Violation: https://myserver.com/ui/violations/2075221495290396672
       Triggered:
         - Watch: 'oprisk-watch', Policy: 'eol-policy', Rule: 'block-eol'
   - iac/gcp/k8s-oss/module.tf:19:1 [rule: gcp-private-endpoint]
+      Violation: https://myserver.com/ui/violations/2075221495319756800
       Triggered:
         - Watch: 'appsec-watch', Policy: 'iac-hardening', Rule: 'block-medium-iac'
   - sast/flask_webgoat/__init__.py:29:12 [rule: cleartext-connection]
+      Violation: https://myserver.com/ui/violations/2075221495323951104
       Triggered:
         - Watch: 'appsec-watch', Policy: 'sast-medium', Rule: 'block-medium-sast'
   - secrets/api_secrets/tokens:1:9 [rule: generic-api-key]
+      Violation: https://myserver.com/ui/violations/2075221495307173888
       Triggered:
         - Watch: 'appsec-watch', Policy: 'no-secrets', Rule: 'block-any-secret'

--- a/testdata/logfailingrules/fail_pr_results.txt
+++ b/testdata/logfailingrules/fail_pr_results.txt
@@ -1,19 +1,25 @@
 The following findings triggered a policy rule configured to fail the pull request:
   - CVE-2025-6624 (snyk@1.995.0)
+      Violation: https://myserver.com/ui/violations/2078174694150950912
       Triggered:
         - Watch: 'pr-security-watch', Policy: 'high-cves', Rule: 'block-high-severity'
   - License: AGPL-3.0 (some-lib@1.0.0)
+      Violation: https://myserver.com/ui/violations/2078174694180311040
       Triggered:
         - Watch: 'pr-license-watch', Policy: 'strict-oss-policy', Rule: 'block-non-permissive'
   - Operational Risk: Deprecated (old-pkg@0.9.0)
+      Violation: https://myserver.com/ui/violations/2078174694192893952
       Triggered:
         - Watch: 'pr-oprisk-watch', Policy: 'deprecated-policy', Rule: 'block-deprecated'
   - iac/gcp/k8s-pipelines-bp/module.tf:105:1 [rule: missing-auto-upgrade]
+      Violation: https://myserver.com/ui/violations/2078175401017004032
       Triggered:
         - Watch: 'pr-appsec-watch', Policy: 'iac-hardening-pr', Rule: 'block-medium-iac-pr'
   - sast/flask_webgoat/ui.py:25:9 [rule: info-leak]
+      Violation: https://myserver.com/ui/violations/2078179035133956096
       Triggered:
         - Watch: 'pr-appsec-watch', Policy: 'sast-low-pr', Rule: 'block-low-sast-pr'
   - secrets/secret_generic/gibberish:1:1 [rule: generic-secret]
+      Violation: https://myserver.com/ui/violations/2078175401000226816
       Triggered:
         - Watch: 'pr-appsec-watch', Policy: 'no-secrets-pr', Rule: 'block-any-secret-pr'

--- a/utils/issues/logfailingrules.go
+++ b/utils/issues/logfailingrules.go
@@ -6,11 +6,15 @@ import (
 	"strings"
 
 	cyclonedx "github.com/CycloneDX/cyclonedx-go"
+	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
 	"github.com/jfrog/jfrog-cli-security/utils/formats/sarifutils"
 	"github.com/jfrog/jfrog-cli-security/utils/formats/violationutils"
 	"github.com/jfrog/jfrog-cli-security/utils/jasutils"
+	clientutils "github.com/jfrog/jfrog-client-go/utils"
 	"github.com/jfrog/jfrog-client-go/utils/log"
 )
+
+const violationUiLinkMinXrayVersion = "3.150.4"
 
 type failAction int
 
@@ -31,18 +35,19 @@ func (t violationTrigger) String() string {
 
 type failingIssue struct {
 	description string
+	violationId string
 	triggers    []violationTrigger
 }
 
-func LogFailingPolicyRulesForPr(violations *violationutils.Violations) {
-	logFailingPolicyRules(violations, failActionPr)
+func LogFailingPolicyRulesForPr(violations *violationutils.Violations, server *config.ServerDetails, xrayVersion string) {
+	logFailingPolicyRules(violations, failActionPr, violationUiBaseUrl(server, xrayVersion))
 }
 
-func LogFailingPolicyRulesForBuild(violations *violationutils.Violations) {
-	logFailingPolicyRules(violations, failActionBuild)
+func LogFailingPolicyRulesForBuild(violations *violationutils.Violations, server *config.ServerDetails, xrayVersion string) {
+	logFailingPolicyRules(violations, failActionBuild, violationUiBaseUrl(server, xrayVersion))
 }
 
-func logFailingPolicyRules(violations *violationutils.Violations, action failAction) {
+func logFailingPolicyRules(violations *violationutils.Violations, action failAction, baseUrl string) {
 	if violations == nil {
 		return
 	}
@@ -50,7 +55,7 @@ func logFailingPolicyRules(violations *violationutils.Violations, action failAct
 	if len(issuesFound) == 0 {
 		return
 	}
-	logFailingIssues(issuesFound, action)
+	logFailingIssues(issuesFound, action, baseUrl)
 }
 
 func collectFailingIssues(violations *violationutils.Violations, action failAction) []failingIssue {
@@ -60,10 +65,10 @@ func collectFailingIssues(violations *violationutils.Violations, action failActi
 	byKey := map[string]*failingIssue{}
 	seenTriggers := map[string]map[string]bool{}
 
-	addTrigger := func(issueKey, description, watch string, p violationutils.Policy) {
+	addTrigger := func(issueKey, description, violationId, watch string, p violationutils.Policy) {
 		issue, exists := byKey[issueKey]
 		if !exists {
-			issue = &failingIssue{description: description}
+			issue = &failingIssue{description: description, violationId: violationId}
 			byKey[issueKey] = issue
 			seenTriggers[issueKey] = map[string]bool{}
 		}
@@ -81,7 +86,7 @@ func collectFailingIssues(violations *violationutils.Violations, action failActi
 			if !isFailActionMatched(p, action) || shouldSkipCvePolicy(p, v) {
 				continue
 			}
-			addTrigger(key, description, v.Watch, p)
+			addTrigger(key, description, v.ViolationId, v.Watch, p)
 		}
 	}
 	for _, v := range violations.License {
@@ -90,7 +95,7 @@ func collectFailingIssues(violations *violationutils.Violations, action failActi
 			if !isFailActionMatched(p, action) {
 				continue
 			}
-			addTrigger(key, description, v.Watch, p)
+			addTrigger(key, description, v.ViolationId, v.Watch, p)
 		}
 	}
 	for _, v := range violations.OpRisk {
@@ -99,7 +104,7 @@ func collectFailingIssues(violations *violationutils.Violations, action failActi
 			if !isFailActionMatched(p, action) {
 				continue
 			}
-			addTrigger(key, description, v.Watch, p)
+			addTrigger(key, description, v.ViolationId, v.Watch, p)
 		}
 	}
 
@@ -115,7 +120,7 @@ func collectFailingIssues(violations *violationutils.Violations, action failActi
 			if !isFailActionMatched(p, action) {
 				continue
 			}
-			addTrigger(key, description, v.Watch, p)
+			addTrigger(key, description, v.ViolationId, v.Watch, p)
 		}
 	}
 
@@ -198,14 +203,17 @@ func isFailActionMatched(p violationutils.Policy, action failAction) bool {
 	return false
 }
 
-func logFailingIssues(issuesFound []failingIssue, action failAction) {
-	log.Info(renderFailingIssues(issuesFound, action))
+func logFailingIssues(issuesFound []failingIssue, action failAction, baseUrl string) {
+	log.Info(renderFailingIssues(issuesFound, action, baseUrl))
 }
 
-func renderFailingIssues(issuesFound []failingIssue, action failAction) string {
+func renderFailingIssues(issuesFound []failingIssue, action failAction, baseUrl string) string {
 	var lines []string
 	for _, issue := range issuesFound {
 		lines = append(lines, "  - "+issue.description)
+		if link := violationUiLink(baseUrl, issue.violationId); link != "" {
+			lines = append(lines, "      Violation: "+link)
+		}
 		lines = append(lines, "      Triggered:")
 		for _, t := range issue.triggers {
 			lines = append(lines, "        - "+t.String())
@@ -220,4 +228,21 @@ func renderFailingIssues(issuesFound []failingIssue, action failAction) string {
 		actionDesc,
 		strings.Join(lines, "\n"),
 	)
+}
+
+func violationUiBaseUrl(server *config.ServerDetails, xrayVersion string) string {
+	if err := clientutils.ValidateMinimumVersion(clientutils.Xray, xrayVersion, violationUiLinkMinXrayVersion); err != nil {
+		return ""
+	}
+	if server.Url != "" {
+		return strings.TrimSuffix(server.Url, "/")
+	}
+	return strings.TrimSuffix(strings.TrimSuffix(server.XrayUrl, "/"), "/xray")
+}
+
+func violationUiLink(baseUrl, violationId string) string {
+	if baseUrl == "" || violationId == "" {
+		return ""
+	}
+	return baseUrl + "/ui/violations/" + violationId
 }

--- a/utils/issues/logfailingrules_test.go
+++ b/utils/issues/logfailingrules_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/CycloneDX/cyclonedx-go"
+	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
 	"github.com/jfrog/jfrog-cli-security/utils/formats"
 	"github.com/jfrog/jfrog-cli-security/utils/formats/violationutils"
 	"github.com/jfrog/jfrog-cli-security/utils/severityutils"
@@ -418,13 +419,15 @@ func TestCollectFailingIssuesForBuild(t *testing.T) {
 }
 
 func TestLogFailingPolicyRulesForPrDoesNotPanic(t *testing.T) {
-	LogFailingPolicyRulesForPr(nil)
-	LogFailingPolicyRulesForPr(&violationutils.Violations{})
+	server := &config.ServerDetails{Url: "https://myserver.com/"}
+	LogFailingPolicyRulesForPr(nil, server, violationUiLinkMinXrayVersion)
+	LogFailingPolicyRulesForPr(&violationutils.Violations{}, server, violationUiLinkMinXrayVersion)
 }
 
 func TestLogFailingPolicyRulesForBuildDoesNotPanic(t *testing.T) {
-	LogFailingPolicyRulesForBuild(nil)
-	LogFailingPolicyRulesForBuild(&violationutils.Violations{})
+	server := &config.ServerDetails{Url: "https://myserver.com/"}
+	LogFailingPolicyRulesForBuild(nil, server, violationUiLinkMinXrayVersion)
+	LogFailingPolicyRulesForBuild(&violationutils.Violations{}, server, violationUiLinkMinXrayVersion)
 }
 
 func TestShouldSkipCvePolicy(t *testing.T) {
@@ -494,8 +497,9 @@ func TestRenderedFailingIssues(t *testing.T) {
 					{
 						ScaViolation: violationutils.ScaViolation{
 							Violation: violationutils.Violation{
-								Watch:    "security-watch",
-								Policies: []violationutils.Policy{{PolicyName: "critical-cves", Rule: "block-critical-severity", FailBuild: true}},
+								ViolationId: "2074859048208711680",
+								Watch:       "security-watch",
+								Policies:    []violationutils.Policy{{PolicyName: "critical-cves", Rule: "block-critical-severity", FailBuild: true}},
 							},
 							ImpactedComponent: &cyclonedx.Component{Name: "lodash", Version: "4.17.20"},
 						},
@@ -506,8 +510,9 @@ func TestRenderedFailingIssues(t *testing.T) {
 					{
 						ScaViolation: violationutils.ScaViolation{
 							Violation: violationutils.Violation{
-								Watch:    "license-watch",
-								Policies: []violationutils.Policy{{PolicyName: "banned-licenses", Rule: "block-copyleft", FailBuild: true}},
+								ViolationId: "2074859048464564224",
+								Watch:       "license-watch",
+								Policies:    []violationutils.Policy{{PolicyName: "banned-licenses", Rule: "block-copyleft", FailBuild: true}},
 							},
 							ImpactedComponent: &cyclonedx.Component{Name: "requests", Version: "2.25.1"},
 						},
@@ -518,8 +523,9 @@ func TestRenderedFailingIssues(t *testing.T) {
 					{
 						ScaViolation: violationutils.ScaViolation{
 							Violation: violationutils.Violation{
-								Watch:    "oprisk-watch",
-								Policies: []violationutils.Policy{{PolicyName: "eol-policy", Rule: "block-eol", FailBuild: true}},
+								ViolationId: "2075221495290396672",
+								Watch:       "oprisk-watch",
+								Policies:    []violationutils.Policy{{PolicyName: "eol-policy", Rule: "block-eol", FailBuild: true}},
 							},
 							ImpactedComponent: &cyclonedx.Component{Name: "old-lib", Version: "0.1.0"},
 						},
@@ -527,13 +533,13 @@ func TestRenderedFailingIssues(t *testing.T) {
 					},
 				},
 				Secrets: []violationutils.JasViolation{
-					jasFindingFixture("appsec-watch", "no-secrets", "block-any-secret", "generic-api-key", "secrets/api_secrets/tokens", 1, 9),
+					jasFindingFixture("appsec-watch", "no-secrets", "block-any-secret", "generic-api-key", "secrets/api_secrets/tokens", 1, 9, "2075221495307173888"),
 				},
 				Iac: []violationutils.JasViolation{
-					jasFindingFixture("appsec-watch", "iac-hardening", "block-medium-iac", "gcp-private-endpoint", "iac/gcp/k8s-oss/module.tf", 19, 1),
+					jasFindingFixture("appsec-watch", "iac-hardening", "block-medium-iac", "gcp-private-endpoint", "iac/gcp/k8s-oss/module.tf", 19, 1, "2075221495319756800"),
 				},
 				Sast: []violationutils.JasViolation{
-					jasFindingFixture("appsec-watch", "sast-medium", "block-medium-sast", "cleartext-connection", "sast/flask_webgoat/__init__.py", 29, 12),
+					jasFindingFixture("appsec-watch", "sast-medium", "block-medium-sast", "cleartext-connection", "sast/flask_webgoat/__init__.py", 29, 12, "2075221495323951104"),
 				},
 			},
 			action:       failActionBuild,
@@ -546,8 +552,9 @@ func TestRenderedFailingIssues(t *testing.T) {
 					{
 						ScaViolation: violationutils.ScaViolation{
 							Violation: violationutils.Violation{
-								Watch:    "pr-security-watch",
-								Policies: []violationutils.Policy{{PolicyName: "high-cves", Rule: "block-high-severity", FailPullRequest: true}},
+								ViolationId: "2078174694150950912",
+								Watch:       "pr-security-watch",
+								Policies:    []violationutils.Policy{{PolicyName: "high-cves", Rule: "block-high-severity", FailPullRequest: true}},
 							},
 							ImpactedComponent: &cyclonedx.Component{Name: "snyk", Version: "1.995.0"},
 						},
@@ -558,8 +565,9 @@ func TestRenderedFailingIssues(t *testing.T) {
 					{
 						ScaViolation: violationutils.ScaViolation{
 							Violation: violationutils.Violation{
-								Watch:    "pr-license-watch",
-								Policies: []violationutils.Policy{{PolicyName: "strict-oss-policy", Rule: "block-non-permissive", FailPullRequest: true}},
+								ViolationId: "2078174694180311040",
+								Watch:       "pr-license-watch",
+								Policies:    []violationutils.Policy{{PolicyName: "strict-oss-policy", Rule: "block-non-permissive", FailPullRequest: true}},
 							},
 							ImpactedComponent: &cyclonedx.Component{Name: "some-lib", Version: "1.0.0"},
 						},
@@ -570,8 +578,9 @@ func TestRenderedFailingIssues(t *testing.T) {
 					{
 						ScaViolation: violationutils.ScaViolation{
 							Violation: violationutils.Violation{
-								Watch:    "pr-oprisk-watch",
-								Policies: []violationutils.Policy{{PolicyName: "deprecated-policy", Rule: "block-deprecated", FailPullRequest: true}},
+								ViolationId: "2078174694192893952",
+								Watch:       "pr-oprisk-watch",
+								Policies:    []violationutils.Policy{{PolicyName: "deprecated-policy", Rule: "block-deprecated", FailPullRequest: true}},
 							},
 							ImpactedComponent: &cyclonedx.Component{Name: "old-pkg", Version: "0.9.0"},
 						},
@@ -579,13 +588,13 @@ func TestRenderedFailingIssues(t *testing.T) {
 					},
 				},
 				Secrets: []violationutils.JasViolation{
-					jasFindingFixture("pr-appsec-watch", "no-secrets-pr", "block-any-secret-pr", "generic-secret", "secrets/secret_generic/gibberish", 1, 1),
+					jasFindingFixture("pr-appsec-watch", "no-secrets-pr", "block-any-secret-pr", "generic-secret", "secrets/secret_generic/gibberish", 1, 1, "2078175401000226816"),
 				},
 				Iac: []violationutils.JasViolation{
-					jasFindingFixture("pr-appsec-watch", "iac-hardening-pr", "block-medium-iac-pr", "missing-auto-upgrade", "iac/gcp/k8s-pipelines-bp/module.tf", 105, 1),
+					jasFindingFixture("pr-appsec-watch", "iac-hardening-pr", "block-medium-iac-pr", "missing-auto-upgrade", "iac/gcp/k8s-pipelines-bp/module.tf", 105, 1, "2078175401017004032"),
 				},
 				Sast: []violationutils.JasViolation{
-					jasFindingFixture("pr-appsec-watch", "sast-low-pr", "block-low-sast-pr", "info-leak", "sast/flask_webgoat/ui.py", 25, 9),
+					jasFindingFixture("pr-appsec-watch", "sast-low-pr", "block-low-sast-pr", "info-leak", "sast/flask_webgoat/ui.py", 25, 9, "2078179035133956096"),
 				},
 			},
 			action:       failActionPr,
@@ -599,16 +608,109 @@ func TestRenderedFailingIssues(t *testing.T) {
 			require.NoError(t, err)
 			// Normalization for Windows
 			expectedText := strings.ReplaceAll(string(expected), "\r\n", "\n")
-			assert.Equal(t, expectedText, renderFailingIssues(issuesFound, tc.action))
+			assert.Equal(t, expectedText, renderFailingIssues(issuesFound, tc.action, "https://myserver.com"))
 		})
 	}
 }
 
-func jasFindingFixture(watch, policy, rule, ruleId, file string, line, column int) violationutils.JasViolation {
+func TestCollectFailingIssuesCapturesViolationId(t *testing.T) {
+	violations := &violationutils.Violations{
+		Sca: []violationutils.CveViolation{
+			{
+				ScaViolation: violationutils.ScaViolation{
+					Violation: violationutils.Violation{
+						ViolationId: "2077479737771958272",
+						Watch:       "security-watch",
+						Policies:    []violationutils.Policy{{PolicyName: "critical-cves", Rule: "block-critical-severity", FailPullRequest: true}},
+					},
+					ImpactedComponent: &cyclonedx.Component{Name: "lodash", Version: "4.17.20"},
+				},
+				CveVulnerability: cyclonedx.Vulnerability{BOMRef: "CVE-2026-4800"},
+			},
+		},
+	}
+	result := collectFailingIssues(violations, failActionPr)
+	require.Len(t, result, 1)
+	assert.Equal(t, "2077479737771958272", result[0].violationId)
+}
+
+func TestViolationUiLink(t *testing.T) {
+	testCases := []struct {
+		name        string
+		baseUrl     string
+		violationId string
+		expected    string
+	}{
+		{name: "Empty base url", baseUrl: "", violationId: "123", expected: ""},
+		{name: "Empty violation id", baseUrl: "https://myserver.com", violationId: "", expected: ""},
+		{name: "Builds link", baseUrl: "https://myserver.com", violationId: "123", expected: "https://myserver.com/ui/violations/123"},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, violationUiLink(tc.baseUrl, tc.violationId))
+		})
+	}
+}
+
+func TestViolationUiBaseUrl(t *testing.T) {
+	testCases := []struct {
+		name        string
+		server      config.ServerDetails
+		xrayVersion string
+		expected    string
+	}{
+		{
+			name:        "Platform url set",
+			server:      config.ServerDetails{Url: "https://myserver.com/"},
+			xrayVersion: violationUiLinkMinXrayVersion,
+			expected:    "https://myserver.com",
+		},
+		{
+			name:        "Derived from xray url",
+			server:      config.ServerDetails{XrayUrl: "https://myserver.com/xray/"},
+			xrayVersion: "3.151.0",
+			expected:    "https://myserver.com",
+		},
+		{
+			name:        "No urls configured",
+			server:      config.ServerDetails{},
+			xrayVersion: "3.151.0",
+			expected:    "",
+		},
+		{
+			name:        "Xray version below the permalink endpoint",
+			server:      config.ServerDetails{Url: "https://myserver.com/"},
+			xrayVersion: "3.150.2",
+			expected:    "",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, violationUiBaseUrl(&tc.server, tc.xrayVersion))
+		})
+	}
+}
+
+func TestRenderFailingIssuesOmitsLinkWhenViolationIdMissing(t *testing.T) {
+	issuesFound := []failingIssue{
+		{
+			description: "CVE-2026-4800 (lodash@4.17.20)",
+			triggers:    []violationTrigger{{watch: "security-watch", policy: "critical-cves", rule: "block-critical-severity"}},
+		},
+	}
+	expected := "The following findings triggered a policy rule configured to fail the pull request:\n" +
+		"  - CVE-2026-4800 (lodash@4.17.20)\n" +
+		"      Triggered:\n" +
+		"        - Watch: 'security-watch', Policy: 'critical-cves', Rule: 'block-critical-severity'"
+	assert.Equal(t, expected, renderFailingIssues(issuesFound, failActionPr, "https://myserver.com"))
+}
+
+func jasFindingFixture(watch, policy, rule, ruleId, file string, line, column int, violationId string) violationutils.JasViolation {
 	return violationutils.JasViolation{
 		Violation: violationutils.Violation{
-			Watch:    watch,
-			Policies: []violationutils.Policy{{PolicyName: policy, Rule: rule, FailBuild: true, FailPullRequest: true}},
+			ViolationId: violationId,
+			Watch:       watch,
+			Policies:    []violationutils.Policy{{PolicyName: policy, Rule: rule, FailBuild: true, FailPullRequest: true}},
 		},
 		Rule: sarif.NewReportingDescriptor().WithID(ruleId),
 		Location: sarif.NewLocation().WithPhysicalLocation(


### PR DESCRIPTION
## Summary

Frogbot logs the watch/policy/rule that failed a PR/build ([XRAY-146332](https://jfrog-int.atlassian.net/browse/XRAY-146332)). This adds the violation link, so a developer can click through from the log instead of searching for it in the UI.

```
  - src/main/resources/app-config.properties:2:8 [rule: REQ.SECRET.GENERIC.TEXT]
      Violation: https://myserver.com/ui/violations/2078175401000226816
      Triggered:
        - Watch: 'my-watch', Policy: 'my-policy', Rule: 'exp'
```

- Link is the [XRAY-147005](https://jfrog-int.atlassian.net/browse/XRAY-147005) permalink. The id is `Violation.ViolationId`, which already *is* the `user_issue_id` that endpoint resolves — no extra call.
- Gated on Xray `3.150.4` (the endpoint's fix version); below it no link is printed.
- v3 only — v2's local violation generator has no resolvable violation id.

## Test plan

- [x] `go test ./utils/ ./utils/issues/`
- [x] Real `scan-pull-request` on a PR with a fail-PR watch — links printed, both resolve 200 to their own violation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
