### PR TITLE
Upload pull request results to GitHub Code Scanning in V3

### DIFF
--- a/scanpullrequest/scanpullrequest.go
+++ b/scanpullrequest/scanpullrequest.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/jfrog/froggit-go/vcsclient"
+	"github.com/jfrog/froggit-go/vcsutils"
 	"github.com/jfrog/jfrog-cli-security/utils/formats"
 	"github.com/jfrog/jfrog-cli-security/utils/jasutils"
 	"github.com/jfrog/jfrog-cli-security/utils/results"
@@ -49,12 +50,17 @@ func (pr *ScanPullRequestCmd) Run(repository utils.Repository, client vcsclient.
 		pullRequestDetails.Target.Owner, pullRequestDetails.Target.Repository, pullRequestDetails.Target.Name))
 	log.Info("-----------------------------------------------------------")
 
-	pullRequestIssues, resultContext, err := auditPullRequestAndReport(&repository, client)
+	pullRequestIssues, resultContext, scanResults, err := auditPullRequestAndReport(&repository, client)
 	if err != nil {
 		return
 	}
 	if err = utils.HandlePullRequestCommentsAfterScan(pullRequestIssues, resultContext, &repository, client, int(pullRequestDetails.ID)); err != nil {
 		return
+	}
+	if repository.Params.Git.UploadPrSecurityResultsToVcs && repository.Params.Git.GitProvider == vcsutils.GitHub && scanResults != nil {
+		if uploadErr := utils.UploadPrSarifToGithubSecurityTab(scanResults, &repository, pullRequestDetails.ID, client); uploadErr != nil {
+			log.Warn(fmt.Sprintf("Failed to upload PR security results to GitHub Code Scanning: %s", uploadErr.Error()))
+		}
 	}
 	if pullRequestIssues.IsFailPrRuleApplied() {
 		issues.LogFailingPolicyRulesForPr(pullRequestIssues.Violations)
@@ -64,7 +70,7 @@ func (pr *ScanPullRequestCmd) Run(repository utils.Repository, client vcsclient.
 	return
 }
 
-func auditPullRequestAndReport(repoConfig *utils.Repository, client vcsclient.VcsClient) (issuesCollection *issues.ScansIssuesCollection, resultContext results.ResultContext, err error) {
+func auditPullRequestAndReport(repoConfig *utils.Repository, client vcsclient.VcsClient) (issuesCollection *issues.ScansIssuesCollection, resultContext results.ResultContext, scanResults *results.SecurityCommandResults, err error) {
 	scanDetails, err := createBaseScanDetails(repoConfig, client)
 	if err != nil {
 		return
@@ -94,7 +100,7 @@ func auditPullRequestAndReport(repoConfig *utils.Repository, client vcsclient.Vc
 			)
 		}
 	}()
-	issuesCollection, err = auditPullRequestCode(repoConfig, scanDetails, sourceBranchWd, targetBranchWd)
+	issuesCollection, scanResults, err = auditPullRequestCode(repoConfig, scanDetails, sourceBranchWd, targetBranchWd)
 	return
 }
 
@@ -133,23 +139,23 @@ func downloadSourceAndTarget(repoConfig *utils.Repository, scanDetails *utils.Sc
 	return
 }
 
-func auditPullRequestCode(repoConfig *utils.Repository, scanDetails *utils.ScanDetails, sourceBranchWd, targetBranchWd string) (issuesCollection *issues.ScansIssuesCollection, err error) {
+func auditPullRequestCode(repoConfig *utils.Repository, scanDetails *utils.ScanDetails, sourceBranchWd, targetBranchWd string) (issuesCollection *issues.ScansIssuesCollection, scanResults *results.SecurityCommandResults, err error) {
 	issuesCollection = &issues.ScansIssuesCollection{}
 	log.Debug("Scanning target branch code...")
 	if targetScanResults, e := auditPullRequestTargetCode(scanDetails, targetBranchWd); e != nil {
 		issuesCollection.AppendStatus(getResultScanStatues(targetScanResults))
-		return issuesCollection, fmt.Errorf("failed to audit target branch. Error: %s", e.Error())
+		return issuesCollection, nil, fmt.Errorf("failed to audit target branch. Error: %s", e.Error())
 	} else {
 		scanDetails.SetResultsToCompare(targetScanResults)
 	}
 	log.Debug("Scanning source branch code...")
-	pullRequestIssues, e := auditPullRequestSourceCode(repoConfig, scanDetails, sourceBranchWd, targetBranchWd)
+	pullRequestIssues, scanResults, e := auditPullRequestSourceCode(repoConfig, scanDetails, sourceBranchWd, targetBranchWd)
 	if e != nil {
 		if pullRequestIssues != nil {
 			// Scan error, report the scan status
 			issuesCollection.AppendStatus(pullRequestIssues.ScanStatus)
 		}
-		return issuesCollection, fmt.Errorf("failed to audit source branch code. Error: %s", e.Error())
+		return issuesCollection, scanResults, fmt.Errorf("failed to audit source branch code. Error: %s", e.Error())
 	}
 	issuesCollection.Append(pullRequestIssues)
 	return
@@ -161,8 +167,8 @@ func auditPullRequestTargetCode(scanDetails *utils.ScanDetails, targetBranchWd s
 	return
 }
 
-func auditPullRequestSourceCode(repoConfig *utils.Repository, scanDetails *utils.ScanDetails, sourceBranchWd, targetBranchWd string) (issuesCollection *issues.ScansIssuesCollection, err error) {
-	scanResults := scanDetails.Audit(sourceBranchWd)
+func auditPullRequestSourceCode(repoConfig *utils.Repository, scanDetails *utils.ScanDetails, sourceBranchWd, targetBranchWd string) (issuesCollection *issues.ScansIssuesCollection, scanResults *results.SecurityCommandResults, err error) {
+	scanResults = scanDetails.Audit(sourceBranchWd)
 	if err = scanResults.GetErrors(); err != nil {
 		issuesCollection = &issues.ScansIssuesCollection{ScanStatus: getResultScanStatues(scanResults)}
 		return

--- a/scanpullrequest/scanpullrequest_test.go
+++ b/scanpullrequest/scanpullrequest_test.go
@@ -424,7 +424,7 @@ func TestAuditDiffInPullRequest(t *testing.T) {
 			repoConfig, client, cleanUpTest := preparePullRequestTest(t, test.projectName)
 			defer cleanUpTest()
 
-			issuesCollection, _, err := auditPullRequestAndReport(&repoConfig, client)
+			issuesCollection, _, _, err := auditPullRequestAndReport(&repoConfig, client)
 			assert.NoError(t, err)
 			assert.NotNil(t, issuesCollection)
 			assert.Len(t, issuesCollection.IacVulnerabilities, test.expectedIssues.Iac)

--- a/utils/consts.go
+++ b/utils/consts.go
@@ -41,6 +41,7 @@ const (
 	GitAzureProjectEnv              = "JF_GIT_AZURE_PROJECT"
 	GitBitBucketUsernameEnv         = "JF_GIT_BB_USERNAME"
 	GitDependencyGraphSubmissionEnv = "JF_UPLOAD_SBOM_TO_VCS"
+	UploadPrSecurityResultsToVcsEnv = "JF_UPLOAD_PR_SECURITY_RESULTS_TO_VCS"
 
 	//#nosec G101 -- False positive - no hardcoded credentials.
 	GitTokenEnv                   = "JF_GIT_TOKEN"

--- a/utils/getconfiguration.go
+++ b/utils/getconfiguration.go
@@ -69,13 +69,14 @@ func (jp *JFrogPlatform) setJfProjectKeyIfExists() (err error) {
 type Git struct {
 	GitProvider vcsutils.VcsProvider
 	vcsclient.VcsInfo
-	RepoOwner                  string
-	RepoName                   string
-	Branches                   []string
-	PullRequestDetails         vcsclient.PullRequestInfo
-	RepositoryCloneUrl         string
-	UploadSbomToVcs            *bool
-	GitlabScanResultsOutputDir string
+	RepoOwner                    string
+	RepoName                     string
+	Branches                     []string
+	PullRequestDetails           vcsclient.PullRequestInfo
+	RepositoryCloneUrl           string
+	UploadSbomToVcs              *bool
+	UploadPrSecurityResultsToVcs bool
+	GitlabScanResultsOutputDir   string
 }
 
 func (g *Git) GetRepositoryHttpsCloneUrl(gitClient vcsclient.VcsClient) (string, error) {
@@ -115,6 +116,9 @@ func (g *Git) setDefaultsIfNeeded(gitParamsFromEnv *Git, commandName string) (er
 		return err
 	}
 	g.UploadSbomToVcs = &envValue
+	if g.UploadPrSecurityResultsToVcs, err = getBoolEnv(UploadPrSecurityResultsToVcsEnv, false); err != nil {
+		return err
+	}
 	return
 }
 

--- a/utils/getconfiguration_test.go
+++ b/utils/getconfiguration_test.go
@@ -54,6 +54,17 @@ func TestExtractParamsFromEnvPlatformScanPullRequest(t *testing.T) {
 	extractAndAssertParamsFromEnv(t, true, ScanPullRequest)
 }
 
+func TestUploadPrSecurityResultsToVcsEnv(t *testing.T) {
+	t.Setenv(UploadPrSecurityResultsToVcsEnv, "true")
+	gitParams := &Git{PullRequestDetails: vcsclient.PullRequestInfo{ID: 1}}
+	gitConfig := &Git{}
+
+	err := gitConfig.setDefaultsIfNeeded(gitParams, ScanPullRequest)
+
+	assert.NoError(t, err)
+	assert.True(t, gitConfig.UploadPrSecurityResultsToVcs)
+}
+
 // Test extraction in ScanRepository command
 // Pull request ID's default is 0, which means we will have branches related variables.
 func TestExtractParamsFromEnvPlatformScanRepository(t *testing.T) {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -27,6 +27,7 @@ import (
 	"github.com/jfrog/jfrog-cli-security/utils/results/conversion"
 	"github.com/jfrog/jfrog-cli-security/utils/results/output"
 	"github.com/jfrog/jfrog-cli-security/utils/techutils"
+	"github.com/jfrog/jfrog-cli-security/utils/xsc"
 	"github.com/jfrog/jfrog-client-go/http/httpclient"
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
 	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
@@ -55,6 +56,10 @@ const (
 		"Update %s version to %s to fix this vulnerability."
 	JfrogHomeDirEnv         = "JFROG_CLI_HOME_DIR"
 	cyclonedxOutputFilename = "cyclonedx.json"
+
+	gitIntegrationEventsCompleteStatus      = "completed"
+	gitIntegrationEventsFailedStatus        = "failed"
+	gitIntegrationEventUploadPrSarifResults = "Source Code Upload PR Results To Code Scanning"
 )
 
 var (
@@ -203,6 +208,58 @@ func UploadSarifResultsToGithubSecurityTab(scanResults *results.SecurityCommandR
 	}
 	log.Info("The complete scanning results have been uploaded to your Code Scanning alerts view")
 	return nil
+}
+
+func UploadPrSarifToGithubSecurityTab(scanResults *results.SecurityCommandResults, repo *Repository, prId int64, client vcsclient.VcsClient) error {
+	report, hasRuns, err := GenerateFrogbotSarifReport(scanResults)
+	if err != nil {
+		return err
+	}
+	if !hasRuns {
+		log.Info("No runs found in the SARIF report, skipping upload to GitHub Security Tab")
+		return nil
+	}
+
+	ctx := context.Background()
+	commit, err := client.GetLatestCommit(ctx, repo.Params.Git.RepoOwner, repo.Params.Git.RepoName, repo.Params.Git.PullRequestDetails.Source.Name)
+	if err != nil {
+		return err
+	}
+
+	prRef := fmt.Sprintf("refs/pull/%d/head", prId)
+	branch := fmt.Sprintf("PR-%d", prId)
+	_, err = client.UploadCodeScanningWithRef(ctx, repo.Params.Git.RepoOwner, repo.Params.Git.RepoName, prRef, commit.Hash, report)
+	if err != nil {
+		sendGitIntegrationEvent(repo, branch, gitIntegrationEventUploadPrSarifResults, err)
+		return err
+	}
+
+	log.Info(fmt.Sprintf("Successfully uploaded security scan results to GitHub Code Scanning for PR #%d", prId))
+	sendGitIntegrationEvent(repo, branch, gitIntegrationEventUploadPrSarifResults, nil)
+	return nil
+}
+
+func sendGitIntegrationEvent(repo *Repository, branch, eventType string, eventErr error) {
+	eventStatus := gitIntegrationEventsCompleteStatus
+	failureReason := ""
+	if eventErr != nil {
+		eventStatus = gitIntegrationEventsFailedStatus
+		failureReason = eventErr.Error()
+	}
+	if err := xsc.SendGitIntegrationEvent(
+		&repo.Server,
+		repo.Params.JFrogPlatform.XrayVersion,
+		repo.Params.JFrogPlatform.JFrogProjectKey,
+		eventType,
+		string(GitHub),
+		repo.Params.Git.RepoOwner,
+		repo.Params.Git.RepoName,
+		branch,
+		eventStatus,
+		failureReason,
+	); err != nil {
+		log.Info(fmt.Sprintf("failed to send git integration event: %s", err.Error()))
+	}
 }
 
 func UploadSbomSnapshotToGithubDependencyGraph(owner, repo string, scanResults *results.SecurityCommandResults, client vcsclient.VcsClient, branch string) error {

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,8 +1,8 @@
 package utils
 
 import (
+	"context"
 	"encoding/json"
-	"github.com/jfrog/jfrog-client-go/xray/services"
 	"net/http/httptest"
 	"os"
 	"path"
@@ -11,15 +11,21 @@ import (
 	"time"
 
 	"github.com/CycloneDX/cyclonedx-go"
+	"github.com/golang/mock/gomock"
 	"github.com/jfrog/froggit-go/vcsclient"
 	"github.com/jfrog/froggit-go/vcsutils"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
 	"github.com/jfrog/jfrog-cli-security/utils"
 	"github.com/jfrog/jfrog-cli-security/utils/formats"
+	"github.com/jfrog/jfrog-cli-security/utils/formats/sarifutils"
 	"github.com/jfrog/jfrog-cli-security/utils/results"
+	"github.com/jfrog/jfrog-cli-security/utils/severityutils"
 	"github.com/jfrog/jfrog-cli-security/utils/techutils"
+	"github.com/jfrog/jfrog-client-go/xray/services"
+	"github.com/owenrumney/go-sarif/v3/pkg/report/v210/sarif"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/jfrog/frogbot/v3/testdata"
 	"github.com/jfrog/frogbot/v3/utils/gitlabreport"
 	"github.com/jfrog/frogbot/v3/utils/outputwriter"
 )
@@ -486,6 +492,50 @@ func TestUploadSbomSnapshotToGithubDependencyGraph(t *testing.T) {
 			restoreEnv()
 		})
 	}
+}
+
+func TestUploadPrSarifToGithubSecurityTab(t *testing.T) {
+	client := testdata.NewMockVcsClient(gomock.NewController(t))
+	scanResults := &results.SecurityCommandResults{
+		ResultsMetaData: results.ResultsMetaData{
+			Entitlements:  results.Entitlements{Jas: true},
+			ResultContext: results.ResultContext{IncludeVulnerabilities: true},
+		},
+		Targets: []*results.TargetResults{{
+			JasResults: &results.JasScansResults{
+				JasVulnerabilities: results.JasScanResults{
+					SastScanResults: []*sarif.Run{
+						sarifutils.CreateRunWithDummyResults(
+							sarifutils.CreateResultWithLocations(
+								"XSS vulnerability",
+								"rule",
+								severityutils.SeverityToSarifSeverityLevel(severityutils.High).String(),
+								sarifutils.CreateLocation("index.js", 1, 1, 1, 10, "snippet"),
+							),
+						),
+					},
+				},
+			},
+		}},
+	}
+	repository := &Repository{Params: Params{
+		Git: Git{
+			RepoOwner:          "owner",
+			RepoName:           "repo",
+			PullRequestDetails: vcsclient.PullRequestInfo{Source: vcsclient.BranchInfo{Name: "feature"}},
+		},
+		JFrogPlatform: JFrogPlatform{XrayVersion: "3.0.0"},
+	}}
+	client.EXPECT().
+		GetLatestCommit(context.Background(), "owner", "repo", "feature").
+		Return(vcsclient.CommitInfo{Hash: "commit-sha"}, nil)
+	client.EXPECT().
+		UploadCodeScanningWithRef(context.Background(), "owner", "repo", "refs/pull/17/head", "commit-sha", gomock.Any()).
+		Return("sarif-id", nil)
+
+	err := UploadPrSarifToGithubSecurityTab(scanResults, repository, 17, client)
+
+	assert.NoError(t, err)
 }
 
 func TestUpdateFixVersionIfMax(t *testing.T) {


### PR DESCRIPTION
Port the V2 opt-in SARIF upload flow so V3 users can publish PR findings with JF_UPLOAD_PR_SECURITY_RESULTS_TO_VCS.

- [ ] All [tests](https://github.com/jfrog/frogbot#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] Update [documentation](https://github.com/jfrog/documentation) about new features / new supported technologies
---

