### PR TITLE
Fix secrets table printing according to configuration - V3

### DIFF
--- a/scanpullrequest/scanpullrequest.go
+++ b/scanpullrequest/scanpullrequest.go
@@ -167,7 +167,7 @@ func auditPullRequestSourceCode(repoConfig *utils.Repository, scanDetails *utils
 		issuesCollection = &issues.ScansIssuesCollection{ScanStatus: getResultScanStatues(scanResults)}
 		return
 	}
-	utils.PrintScanResultsTable(scanResults)
+	utils.PrintScanResultsTable(scanResults, repoConfig.FrogbotConfig.ShowSecretsAsPrComment)
 	// Set JAS output flags based on the scan results
 	repoConfig.OutputWriter.SetJasOutputFlags(scanResults.Entitlements.Jas, scanResults.HasJasScansResults(jasutils.Applicability))
 	filterFailedResultsIfScannersFailuresAreAllowed(scanDetails.ResultsToCompare, scanResults, repoConfig.Params.ConfigProfile.GeneralConfig.FailUponAnyScannerError, sourceBranchWd, targetBranchWd)

--- a/scanrepository/scanrepository.go
+++ b/scanrepository/scanrepository.go
@@ -158,7 +158,7 @@ func (sr *ScanRepositoryCmd) scanAndFixBranch(repository *utils.Repository) (sca
 			err = errors.Join(err, policyErr)
 		}
 	}()
-	utils.PrintScanResultsTable(scanResults)
+	utils.PrintScanResultsTable(scanResults, repository.FrogbotConfig.ShowSecretsAsPrComment)
 	sr.uploadResultsToGithubDashboardsIfNeeded(repository, scanResults)
 	sr.uploadGitLabScanResultsIfNeeded(repository, scanResults)
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -23,6 +23,7 @@ import (
 	"github.com/jfrog/jfrog-cli-security/utils"
 	"github.com/jfrog/jfrog-cli-security/utils/formats"
 	"github.com/jfrog/jfrog-cli-security/utils/formats/snapshotconvertor"
+	"github.com/jfrog/jfrog-cli-security/utils/formats/violationutils"
 	"github.com/jfrog/jfrog-cli-security/utils/results"
 	"github.com/jfrog/jfrog-cli-security/utils/results/conversion"
 	"github.com/jfrog/jfrog-cli-security/utils/results/output"
@@ -31,6 +32,7 @@ import (
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
 	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
 	"github.com/jfrog/jfrog-client-go/utils/log"
+	"github.com/owenrumney/go-sarif/v3/pkg/report/v210/sarif"
 
 	"github.com/jfrog/frogbot/v3/utils/gitlabreport"
 	"github.com/jfrog/frogbot/v3/utils/issues"
@@ -65,6 +67,11 @@ var (
 var BuildToolsDependenciesMap = map[techutils.Technology][]string{
 	techutils.Go:  {"github.com/golang/go"},
 	techutils.Pip: {"pip", "setuptools", "wheel"},
+}
+
+type savedTargetSecrets struct {
+	target  *results.TargetResults
+	secrets []*sarif.Run
 }
 
 type ErrUnsupportedFix struct {
@@ -543,9 +550,13 @@ func writeCycloneDxToDir(outputDir string, scanResults *results.SecurityCommandR
 	return nil
 }
 
-func PrintScanResultsTable(scanResults *results.SecurityCommandResults) {
+func PrintScanResultsTable(scanResults *results.SecurityCommandResults, showSecrets bool) {
 	if scanResults == nil {
 		return
+	}
+	if !showSecrets {
+		restore := hideSecretsForPrinting(scanResults)
+		defer restore()
 	}
 	extraMessages := []string{}
 	if scanResults.ResultsPlatformUrl != "" {
@@ -556,5 +567,29 @@ func PrintScanResultsTable(scanResults *results.SecurityCommandResults) {
 		SetOutputFormat(format.Table).
 		PrintScanResults(); err != nil {
 		log.Warn(fmt.Sprintf("Failed to print scan results table: %s", err.Error()))
+	}
+}
+
+func hideSecretsForPrinting(scanResults *results.SecurityCommandResults) (restore func()) {
+	var savedTargets []savedTargetSecrets
+	for _, target := range scanResults.Targets {
+		if target == nil || target.JasResults == nil {
+			continue
+		}
+		savedTargets = append(savedTargets, savedTargetSecrets{target: target, secrets: target.JasResults.JasVulnerabilities.SecretsScanResults})
+		target.JasResults.JasVulnerabilities.SecretsScanResults = nil
+	}
+	var savedViolationsSecrets []violationutils.JasViolation
+	if scanResults.Violations != nil {
+		savedViolationsSecrets = scanResults.Violations.Secrets
+		scanResults.Violations.Secrets = nil
+	}
+	return func() {
+		for _, saved := range savedTargets {
+			saved.target.JasResults.JasVulnerabilities.SecretsScanResults = saved.secrets
+		}
+		if scanResults.Violations != nil {
+			scanResults.Violations.Secrets = savedViolationsSecrets
+		}
 	}
 }

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"bytes"
 	"encoding/json"
+	"io"
 	"net/http/httptest"
 	"os"
 	"path"
@@ -16,11 +17,15 @@ import (
 	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
 	"github.com/jfrog/jfrog-cli-security/utils"
 	"github.com/jfrog/jfrog-cli-security/utils/formats"
+	"github.com/jfrog/jfrog-cli-security/utils/formats/sarifutils"
+	"github.com/jfrog/jfrog-cli-security/utils/formats/violationutils"
 	"github.com/jfrog/jfrog-cli-security/utils/results"
 	"github.com/jfrog/jfrog-cli-security/utils/techutils"
 	"github.com/jfrog/jfrog-client-go/utils/log"
 	"github.com/jfrog/jfrog-client-go/xray/services"
+	"github.com/owenrumney/go-sarif/v3/pkg/report/v210/sarif"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/jfrog/frogbot/v3/utils/gitlabreport"
 	"github.com/jfrog/frogbot/v3/utils/outputwriter"
@@ -640,24 +645,31 @@ func TestWriteScanResultsToGitlabDir(t *testing.T) {
 }
 
 func TestPrintScanResultsTable(t *testing.T) {
+	const secretSnippet = "my-snippet-1234"
+
 	tests := []struct {
-		name        string
-		scanResults *results.SecurityCommandResults
+		name                 string
+		scanResults          *results.SecurityCommandResults
+		showSecrets          bool
+		expectSecretInOutput bool
 	}{
 		{
 			name:        "nil scan results should not panic",
 			scanResults: nil,
+			showSecrets: true,
 		},
 		{
 			name: "empty scan results should not panic",
 			scanResults: &results.SecurityCommandResults{
 				Targets: []*results.TargetResults{},
 			},
+			showSecrets: true,
 		},
 		{
-			name: "scan results with vulnerabilities should print without error",
+			name: "scan results should print without error",
 			scanResults: &results.SecurityCommandResults{
 				ResultsMetaData: results.ResultsMetaData{
+					Entitlements:  results.Entitlements{Jas: true},
 					ResultContext: results.ResultContext{IncludeVulnerabilities: true},
 				},
 				Targets: []*results.TargetResults{{
@@ -673,18 +685,100 @@ func TestPrintScanResultsTable(t *testing.T) {
 							},
 						}},
 					},
+					JasResults: &results.JasScansResults{
+						JasVulnerabilities: results.JasScanResults{
+							SecretsScanResults: []*sarif.Run{
+								sarifutils.CreateRunWithDummyResultAndRuleInformation(
+									sarifutils.CreateResultWithLocations("Secret", "rule", "error",
+										sarifutils.CreateLocation("index.js", 5, 6, 7, 8, secretSnippet),
+									), "", "", nil, nil),
+							},
+						},
+					},
 				}},
 			},
+			showSecrets:          true,
+			expectSecretInOutput: true,
+		},
+		{
+			name: "secrets are hidden when not allowed",
+			scanResults: &results.SecurityCommandResults{
+				ResultsMetaData: results.ResultsMetaData{
+					Entitlements:  results.Entitlements{Jas: true},
+					ResultContext: results.ResultContext{IncludeVulnerabilities: true},
+				},
+				Targets: []*results.TargetResults{{
+					ScanTarget: results.ScanTarget{Target: "test-target"},
+					JasResults: &results.JasScansResults{
+						JasVulnerabilities: results.JasScanResults{
+							SecretsScanResults: []*sarif.Run{
+								sarifutils.CreateRunWithDummyResultAndRuleInformation(
+									sarifutils.CreateResultWithLocations("Secret", "rule", "error",
+										sarifutils.CreateLocation("index.js", 5, 6, 7, 8, secretSnippet),
+									), "", "", nil, nil),
+							},
+						},
+					},
+				}},
+			},
+			showSecrets:          false,
+			expectSecretInOutput: false,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			originalStdout := os.Stdout
+			r, w, err := os.Pipe()
+			require.NoError(t, err)
+			os.Stdout = w
+
 			assert.NotPanics(t, func() {
-				PrintScanResultsTable(test.scanResults)
+				PrintScanResultsTable(test.scanResults, test.showSecrets)
 			})
+
+			require.NoError(t, w.Close())
+			os.Stdout = originalStdout
+			capturedOutput, err := io.ReadAll(r)
+			require.NoError(t, err)
+
+			if test.expectSecretInOutput {
+				assert.Contains(t, string(capturedOutput), secretSnippet)
+			} else {
+				assert.NotContains(t, string(capturedOutput), secretSnippet)
+			}
 		})
 	}
+}
+
+func TestHideSecretsForPrinting(t *testing.T) {
+	secretRun := &sarif.Run{}
+	violationSecret := violationutils.JasViolation{}
+
+	scanResults := &results.SecurityCommandResults{
+		Targets: []*results.TargetResults{
+			{
+				JasResults: &results.JasScansResults{
+					JasVulnerabilities: results.JasScanResults{
+						SecretsScanResults: []*sarif.Run{secretRun},
+					},
+				},
+			},
+			// Target without JAS results, to make sure it is skipped without panicking.
+			{},
+		},
+		Violations: &violationutils.Violations{
+			Secrets: []violationutils.JasViolation{violationSecret},
+		},
+	}
+
+	restore := hideSecretsForPrinting(scanResults)
+	assert.Nil(t, scanResults.Targets[0].JasResults.JasVulnerabilities.SecretsScanResults)
+	assert.Nil(t, scanResults.Violations.Secrets)
+
+	restore()
+	assert.Equal(t, []*sarif.Run{secretRun}, scanResults.Targets[0].JasResults.JasVulnerabilities.SecretsScanResults)
+	assert.Equal(t, []violationutils.JasViolation{violationSecret}, scanResults.Violations.Secrets)
 }
 
 func TestPrintScanResultsTableResultsPlatformURL(t *testing.T) {
@@ -721,7 +815,7 @@ func TestPrintScanResultsTableResultsPlatformURL(t *testing.T) {
 				Targets: []*results.TargetResults{},
 			}
 
-			PrintScanResultsTable(scanResults)
+			PrintScanResultsTable(scanResults, true)
 
 			if testCase.expectURL {
 				assert.Contains(t, output.String(), resultsURL)


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/frogbot#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] Update [documentation](https://github.com/jfrog/documentation) about new features / new supported technologies
---
This fix prevents us to print secrets results if configured so in the config profile
