### PR TITLE
Adding username + password based authentication

### DIFF
--- a/utils/consts.go
+++ b/utils/consts.go
@@ -29,8 +29,8 @@ const (
 	jfrogXrayUrlEnv        = "JF_XRAY_URL"
 	jfrogArtifactoryUrlEnv = "JF_ARTIFACTORY_URL"
 	jfrogReleasesRepoEnv   = "JF_RELEASES_REPO"
-	JFrogUserEnv           = "JF_USER"     // TODO should add support once Catalog Enrich API is fixed (remember adding to extraction tests)
-	JFrogPasswordEnv       = "JF_PASSWORD" // TODO should add support once Catalog Enrich API is fixed (remember adding to extraction tests)
+	JFrogUserEnv           = "JF_USER"
+	JFrogPasswordEnv       = "JF_PASSWORD"
 	JFrogTokenEnv          = "JF_ACCESS_TOKEN"
 	jfrogProjectEnv        = "JF_PROJECT_KEY"
 

--- a/utils/getconfiguration.go
+++ b/utils/getconfiguration.go
@@ -225,13 +225,13 @@ func extractJFrogCredentialsFromEnvs() (*coreconfig.ServerDetails, error) {
 		server.XrayUrl = platformUrl + "/xray/"
 		server.ArtifactoryUrl = platformUrl + "/artifactory/"
 	}
-	password := getTrimmedEnv(JFrogPasswordEnv)
 	user := getTrimmedEnv(JFrogUserEnv)
-	if user != "" && password != "" {
+	password := getTrimmedEnv(JFrogPasswordEnv)
+	if accessToken := getTrimmedEnv(JFrogTokenEnv); accessToken != "" {
+		server.AccessToken = accessToken
+	} else if user != "" && password != "" {
 		server.User = user
 		server.Password = password
-	} else if accessToken := getTrimmedEnv(JFrogTokenEnv); accessToken != "" {
-		server.AccessToken = accessToken
 	} else {
 		return nil, fmt.Errorf("%s and %s or %s environment variables are missing", JFrogUserEnv, JFrogPasswordEnv, JFrogTokenEnv)
 	}

--- a/utils/getconfiguration.go
+++ b/utils/getconfiguration.go
@@ -225,10 +225,15 @@ func extractJFrogCredentialsFromEnvs() (*coreconfig.ServerDetails, error) {
 		server.XrayUrl = platformUrl + "/xray/"
 		server.ArtifactoryUrl = platformUrl + "/artifactory/"
 	}
-	if accessToken := getTrimmedEnv(JFrogTokenEnv); accessToken != "" {
+	password := getTrimmedEnv(JFrogPasswordEnv)
+	user := getTrimmedEnv(JFrogUserEnv)
+	if user != "" && password != "" {
+		server.User = user
+		server.Password = password
+	} else if accessToken := getTrimmedEnv(JFrogTokenEnv); accessToken != "" {
 		server.AccessToken = accessToken
 	} else {
-		return nil, fmt.Errorf("%s environment variable is missing", JFrogTokenEnv)
+		return nil, fmt.Errorf("%s and %s or %s environment variables are missing", JFrogUserEnv, JFrogPasswordEnv, JFrogTokenEnv)
 	}
 	return &server, nil
 }

--- a/utils/getconfiguration_test.go
+++ b/utils/getconfiguration_test.go
@@ -26,16 +26,57 @@ var (
 )
 
 func TestExtractJFrogCredentialsFromEnvs(t *testing.T) {
+	defer func() {
+		assert.NoError(t, SanitizeEnv())
+	}()
 	SetEnvAndAssert(t, map[string]string{
-		JFrogUrlEnv:   "",
-		JFrogTokenEnv: "",
+		JFrogUrlEnv:      "",
+		JFrogTokenEnv:    "",
+		JFrogUserEnv:     "",
+		JFrogPasswordEnv: "",
 	})
+	// No platform URL
 	_, err := extractJFrogCredentialsFromEnvs()
 	assert.EqualError(t, err, "JF_URL or JF_XRAY_URL and JF_ARTIFACTORY_URL environment variables are missing")
 
 	SetEnvAndAssert(t, map[string]string{JFrogUrlEnv: "http://127.0.0.1:8081"})
+	// No any authentication method
 	_, err = extractJFrogCredentialsFromEnvs()
-	assert.EqualError(t, err, "JF_ACCESS_TOKEN environment variable is missing")
+	assert.EqualError(t, err, "JF_USER and JF_PASSWORD or JF_ACCESS_TOKEN environment variables are missing")
+
+	// Access token only, no username and password
+	SetEnvAndAssert(t, map[string]string{
+		JFrogUrlEnv:      "http://127.0.0.1:8081",
+		JFrogUserEnv:     "",
+		JFrogPasswordEnv: "",
+		JFrogTokenEnv:    "token",
+	})
+	server, err := extractJFrogCredentialsFromEnvs()
+	assert.NoError(t, err)
+	assert.Equal(t, "token", server.AccessToken)
+	assert.Empty(t, server.User)
+	assert.Empty(t, server.Password)
+
+	SetEnvAndAssert(t, map[string]string{
+		JFrogUrlEnv:   "http://127.0.0.1:8081",
+		JFrogUserEnv:  "admin",
+		JFrogTokenEnv: "",
+	})
+	// Username with no password
+	_, err = extractJFrogCredentialsFromEnvs()
+	assert.EqualError(t, err, "JF_USER and JF_PASSWORD or JF_ACCESS_TOKEN environment variables are missing")
+
+	// Username and password
+	SetEnvAndAssert(t, map[string]string{
+		JFrogUrlEnv:      "http://127.0.0.1:8081",
+		JFrogUserEnv:     "admin",
+		JFrogPasswordEnv: "password",
+	})
+	server, err = extractJFrogCredentialsFromEnvs()
+	assert.NoError(t, err)
+	assert.Equal(t, "admin", server.User)
+	assert.Equal(t, "password", server.Password)
+	assert.Empty(t, server.AccessToken)
 }
 
 // Test extraction of env params in ScanPullRequest command
@@ -98,6 +139,34 @@ func TestExtractParamsFromEnvToken(t *testing.T) {
 		GitBitBucketUsernameEnv: "bbuser",
 	})
 	extractAndAssertParamsFromEnv(t, true, ScanRepository)
+}
+
+func TestExtractParamsFromEnvBasicAuth(t *testing.T) {
+	defer func() {
+		assert.NoError(t, SanitizeEnv())
+	}()
+	SetEnvAndAssert(t, map[string]string{
+		JFrogUrlEnv:             "http://127.0.0.1:8081",
+		JFrogUserEnv:            "admin",
+		JFrogPasswordEnv:        "password",
+		GitProvider:             string(BitbucketServer),
+		GitRepoOwnerEnv:         "jfrog",
+		GitRepoEnv:              "frogbot",
+		GitTokenEnv:             "123456789",
+		GitBaseBranchEnv:        "dev",
+		GitBitBucketUsernameEnv: "bbuser",
+	})
+
+	server, err := extractJFrogCredentialsFromEnvs()
+	assert.NoError(t, err)
+	gitParams, err := extractGitParamsFromEnvs()
+	assert.NoError(t, err)
+	_, err = BuildRepositoryFromEnv("xrayVersion", "xscVersion", nil, gitParams, server, ScanRepository)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "admin", server.User)
+	assert.Equal(t, "password", server.Password)
+	assert.Empty(t, server.AccessToken)
 }
 
 func TestExtractVcsProviderFromEnv(t *testing.T) {
@@ -202,7 +271,6 @@ func extractAndAssertParamsFromEnv(t *testing.T, platformUrl bool, commandName s
 	}
 	assert.Equal(t, "http://127.0.0.1:8081/artifactory/", configServer.ArtifactoryUrl)
 	assert.Equal(t, "http://127.0.0.1:8081/xray/", configServer.XrayUrl)
-	// TODO when basic auth (username + password) if fixed, make sure to add a check for it here and in the tests
 	assert.Equal(t, "token", configServer.AccessToken)
 
 	assert.Equal(t, vcsutils.BitbucketServer, configFile.GitProvider)

--- a/utils/getconfiguration_test.go
+++ b/utils/getconfiguration_test.go
@@ -77,6 +77,19 @@ func TestExtractJFrogCredentialsFromEnvs(t *testing.T) {
 	assert.Equal(t, "admin", server.User)
 	assert.Equal(t, "password", server.Password)
 	assert.Empty(t, server.AccessToken)
+
+	// Both access token and username/password set - access token takes precedence
+	SetEnvAndAssert(t, map[string]string{
+		JFrogUrlEnv:      "http://127.0.0.1:8081",
+		JFrogUserEnv:     "admin",
+		JFrogPasswordEnv: "password",
+		JFrogTokenEnv:    "token",
+	})
+	server, err = extractJFrogCredentialsFromEnvs()
+	assert.NoError(t, err)
+	assert.Equal(t, "token", server.AccessToken)
+	assert.Empty(t, server.User)
+	assert.Empty(t, server.Password)
 }
 
 // Test extraction of env params in ScanPullRequest command


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/frogbot#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
- [ ] Update [documentation](https://github.com/jfrog/documentation) about new features / new supported technologies
---

Introducing username and password authentication via the following env vars: JF_USER, JF_PASSWORD
This can be used instead JF_ACCESS_TOKEN (and OIDC for github)
NOTE: Only one auth method should be provided at a time