### PR TITLE
XRAY-133157 - Scan the merge base instead of the target branch tip

### DIFF
--- a/scanpullrequest/scanpullrequest.go
+++ b/scanpullrequest/scanpullrequest.go
@@ -241,13 +241,16 @@ func resolveTargetRef(scanDetails *utils.ScanDetails, target vcsclient.BranchInf
 
 type repoDownloader func(client vcsclient.VcsClient, owner, repository, ref string) (string, func() error, error)
 
-func downloadTargetAtRef(client vcsclient.VcsClient, target vcsclient.BranchInfo, ref string, download repoDownloader) (string, func() error, error) {
-	wd, cleanup, err := download(client, target.Owner, target.Repository, ref)
-	if err == nil || ref == target.Name {
-		return wd, cleanup, err
+func downloadTargetAtRef(client vcsclient.VcsClient, target vcsclient.BranchInfo, mergeBaseSha string, downloadCommit, downloadBranch repoDownloader) (string, func() error, error) {
+	if mergeBaseSha == target.Name {
+		return downloadBranch(client, target.Owner, target.Repository, target.Name)
 	}
-	log.Warn(fmt.Sprintf("Failed to download %s at merge base %s, scanning the tip of %s instead. Scan results may include findings that were already fixed on %s. Error: %s", target.Name, ref, target.Name, target.Name, err.Error()))
-	return download(client, target.Owner, target.Repository, target.Name)
+	wd, cleanup, err := downloadCommit(client, target.Owner, target.Repository, mergeBaseSha)
+	if err == nil {
+		return wd, cleanup, nil
+	}
+	log.Warn(fmt.Sprintf("Failed to download %s at merge base %s, scanning the tip of %s instead. Scan results may include findings that were already fixed on %s. Error: %s", target.Name, mergeBaseSha, target.Name, target.Name, err.Error()))
+	return downloadBranch(client, target.Owner, target.Repository, target.Name)
 }
 
 func downloadSourceAndTarget(repoConfig *utils.Repository, scanDetails *utils.ScanDetails) (sourceBranchWd, targetBranchWd string, cleanup func() error, err error) {
@@ -266,7 +269,7 @@ func downloadSourceAndTarget(repoConfig *utils.Repository, scanDetails *utils.Sc
 	}
 	target := repoConfig.Params.Git.PullRequestDetails.Target
 	targetRef := resolveTargetRef(scanDetails, target, scanDetails.PullRequestDetails.Source.Name)
-	if targetBranchWd, cleanupTarget, err = downloadTargetAtRef(scanDetails.Client(), target, targetRef, utils.DownloadRepoToTempDir); err != nil {
+	if targetBranchWd, cleanupTarget, err = downloadTargetAtRef(scanDetails.Client(), target, targetRef, utils.DownloadRepoCommitToTempDir, utils.DownloadRepoToTempDir); err != nil {
 		err = fmt.Errorf("failed to download target branch code. Error: %s", err.Error())
 		return
 	}

--- a/scanpullrequest/scanpullrequest.go
+++ b/scanpullrequest/scanpullrequest.go
@@ -217,10 +217,19 @@ func verifyWorkflowContainsFrogbotEnvironment(client vcsclient.VcsClient) error 
 }
 
 func resolveTargetRef(scanDetails *utils.ScanDetails, target vcsclient.BranchInfo, sourceName string) string {
+	source := scanDetails.PullRequestDetails.Source
+	if !strings.EqualFold(source.Owner, target.Owner) || !strings.EqualFold(source.Repository, target.Repository) {
+		log.Warn(fmt.Sprintf("The pull request comes from a fork, where the merge base cannot be resolved against %s/%s. Scan results may include findings that were already fixed on %s. Rebasing %s onto %s avoids this.", target.Owner, target.Repository, target.Name, sourceName, target.Name))
+		return target.Name
+	}
 	mergeBase, err := scanDetails.Client().GetMergeBase(context.Background(), target.Owner, target.Repository, target.Name, sourceName)
-	if err == nil {
+	if err == nil && mergeBase.Hash != "" {
 		log.Info(fmt.Sprintf("Comparing against merge base %s of %s and %s", mergeBase.Hash, target.Name, sourceName))
 		return mergeBase.Hash
+	}
+	if err == nil {
+		log.Warn(fmt.Sprintf("Resolving the merge base of %s and %s returned an empty commit, scanning the tip of %s instead. Scan results may include findings that were already fixed on %s.", target.Name, sourceName, target.Name, target.Name))
+		return target.Name
 	}
 	if errors.Is(err, vcsclient.ErrMergeBaseUnsupported) {
 		log.Warn(fmt.Sprintf("Merge base resolution is not yet supported for this git provider. Scan results may include findings that were already fixed on %s. Rebasing %s onto %s avoids this.", target.Name, sourceName, target.Name))

--- a/scanpullrequest/scanpullrequest.go
+++ b/scanpullrequest/scanpullrequest.go
@@ -239,6 +239,17 @@ func resolveTargetRef(scanDetails *utils.ScanDetails, target vcsclient.BranchInf
 	return target.Name
 }
 
+type repoDownloader func(client vcsclient.VcsClient, owner, repository, ref string) (string, func() error, error)
+
+func downloadTargetAtRef(client vcsclient.VcsClient, target vcsclient.BranchInfo, ref string, download repoDownloader) (string, func() error, error) {
+	wd, cleanup, err := download(client, target.Owner, target.Repository, ref)
+	if err == nil || ref == target.Name {
+		return wd, cleanup, err
+	}
+	log.Warn(fmt.Sprintf("Failed to download %s at merge base %s, scanning the tip of %s instead. Scan results may include findings that were already fixed on %s. Error: %s", target.Name, ref, target.Name, target.Name, err.Error()))
+	return download(client, target.Owner, target.Repository, target.Name)
+}
+
 func downloadSourceAndTarget(repoConfig *utils.Repository, scanDetails *utils.ScanDetails) (sourceBranchWd, targetBranchWd string, cleanup func() error, err error) {
 	cleanupSource := func() error { return nil }
 	cleanupTarget := func() error { return nil }
@@ -255,7 +266,7 @@ func downloadSourceAndTarget(repoConfig *utils.Repository, scanDetails *utils.Sc
 	}
 	target := repoConfig.Params.Git.PullRequestDetails.Target
 	targetRef := resolveTargetRef(scanDetails, target, scanDetails.PullRequestDetails.Source.Name)
-	if targetBranchWd, cleanupTarget, err = utils.DownloadRepoToTempDir(scanDetails.Client(), target.Owner, target.Repository, targetRef); err != nil {
+	if targetBranchWd, cleanupTarget, err = downloadTargetAtRef(scanDetails.Client(), target, targetRef, utils.DownloadRepoToTempDir); err != nil {
 		err = fmt.Errorf("failed to download target branch code. Error: %s", err.Error())
 		return
 	}

--- a/scanpullrequest/scanpullrequest.go
+++ b/scanpullrequest/scanpullrequest.go
@@ -216,6 +216,20 @@ func verifyWorkflowContainsFrogbotEnvironment(client vcsclient.VcsClient) error 
 	return nil
 }
 
+func resolveTargetRef(scanDetails *utils.ScanDetails, target vcsclient.BranchInfo, sourceName string) string {
+	mergeBase, err := scanDetails.Client().GetMergeBase(context.Background(), target.Owner, target.Repository, target.Name, sourceName)
+	if err == nil {
+		log.Info(fmt.Sprintf("Comparing against merge base %s of %s and %s", mergeBase.Hash, target.Name, sourceName))
+		return mergeBase.Hash
+	}
+	if errors.Is(err, vcsclient.ErrMergeBaseUnsupported) {
+		log.Warn(fmt.Sprintf("Merge base resolution is not yet supported for this git provider. Scan results may include findings that were already fixed on %s. Rebasing %s onto %s avoids this.", target.Name, sourceName, target.Name))
+	} else {
+		log.Warn(fmt.Sprintf("Failed to resolve the merge base of %s and %s, scanning the tip of %s instead. Scan results may include findings that were already fixed on %s. Error: %s", target.Name, sourceName, target.Name, target.Name, err.Error()))
+	}
+	return target.Name
+}
+
 func downloadSourceAndTarget(repoConfig *utils.Repository, scanDetails *utils.ScanDetails) (sourceBranchWd, targetBranchWd string, cleanup func() error, err error) {
 	cleanupSource := func() error { return nil }
 	cleanupTarget := func() error { return nil }
@@ -231,7 +245,8 @@ func downloadSourceAndTarget(repoConfig *utils.Repository, scanDetails *utils.Sc
 		return
 	}
 	target := repoConfig.Params.Git.PullRequestDetails.Target
-	if targetBranchWd, cleanupTarget, err = utils.DownloadRepoToTempDir(scanDetails.Client(), target.Owner, target.Repository, target.Name); err != nil {
+	targetRef := resolveTargetRef(scanDetails, target, scanDetails.PullRequestDetails.Source.Name)
+	if targetBranchWd, cleanupTarget, err = utils.DownloadRepoToTempDir(scanDetails.Client(), target.Owner, target.Repository, targetRef); err != nil {
 		err = fmt.Errorf("failed to download target branch code. Error: %s", err.Error())
 		return
 	}

--- a/scanpullrequest/scanpullrequest_test.go
+++ b/scanpullrequest/scanpullrequest_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/jfrog/frogbot/v3/utils"
 	"github.com/jfrog/frogbot/v3/utils/issues"
 	"github.com/jfrog/frogbot/v3/utils/outputwriter"
+	"github.com/jfrog/jfrog-client-go/utils/log"
 )
 
 //go:generate go run github.com/golang/mock/mockgen@v1.6.0 -destination=../testdata/vcsclientmock.go -package=testdata github.com/jfrog/froggit-go/vcsclient VcsClient
@@ -1759,4 +1760,50 @@ func createSecurityCommandResultsForTest(targetLocation string, targetName strin
 	}
 
 	return result
+}
+
+func TestResolveTargetRefUsesMergeBase(t *testing.T) {
+	client := CreateMockVcsClient(t)
+	client.EXPECT().GetMergeBase(context.Background(), "owner", "repo", "master", "feature").
+		Return(vcsclient.CommitInfo{Hash: "abc123"}, nil)
+
+	scanDetails := utils.NewScanDetails(client, &coreconfig.ServerDetails{}, &utils.Git{})
+	target := vcsclient.BranchInfo{Owner: "owner", Repository: "repo", Name: "master"}
+
+	assert.Equal(t, "abc123", resolveTargetRef(scanDetails, target, "feature"))
+}
+
+func TestResolveTargetRefWarnsWhenProviderUnsupported(t *testing.T) {
+	originalLogger := log.GetLogger()
+	t.Cleanup(func() { log.SetLogger(originalLogger) })
+	var output bytes.Buffer
+	log.SetLogger(log.NewLogger(log.INFO, &output))
+
+	client := CreateMockVcsClient(t)
+	client.EXPECT().GetMergeBase(context.Background(), "owner", "repo", "master", "feature").
+		Return(vcsclient.CommitInfo{}, vcsclient.ErrMergeBaseUnsupported)
+
+	scanDetails := utils.NewScanDetails(client, &coreconfig.ServerDetails{}, &utils.Git{})
+	target := vcsclient.BranchInfo{Owner: "owner", Repository: "repo", Name: "master"}
+
+	assert.Equal(t, "master", resolveTargetRef(scanDetails, target, "feature"))
+	assert.Contains(t, output.String(), "not yet supported")
+	assert.Contains(t, output.String(), "Rebasing")
+}
+
+func TestResolveTargetRefWarnsOnApiFailure(t *testing.T) {
+	originalLogger := log.GetLogger()
+	t.Cleanup(func() { log.SetLogger(originalLogger) })
+	var output bytes.Buffer
+	log.SetLogger(log.NewLogger(log.INFO, &output))
+
+	client := CreateMockVcsClient(t)
+	client.EXPECT().GetMergeBase(context.Background(), "owner", "repo", "master", "feature").
+		Return(vcsclient.CommitInfo{}, errors.New("vcs api is down"))
+
+	scanDetails := utils.NewScanDetails(client, &coreconfig.ServerDetails{}, &utils.Git{})
+	target := vcsclient.BranchInfo{Owner: "owner", Repository: "repo", Name: "master"}
+
+	assert.Equal(t, "master", resolveTargetRef(scanDetails, target, "feature"))
+	assert.Contains(t, output.String(), "vcs api is down")
 }

--- a/scanpullrequest/scanpullrequest_test.go
+++ b/scanpullrequest/scanpullrequest_test.go
@@ -1768,6 +1768,10 @@ func TestResolveTargetRefUsesMergeBase(t *testing.T) {
 		Return(vcsclient.CommitInfo{Hash: "abc123"}, nil)
 
 	scanDetails := utils.NewScanDetails(client, &coreconfig.ServerDetails{}, &utils.Git{})
+	scanDetails.PullRequestDetails = vcsclient.PullRequestInfo{
+		Source: vcsclient.BranchInfo{Owner: "owner", Repository: "repo", Name: "feature"},
+		Target: vcsclient.BranchInfo{Owner: "owner", Repository: "repo", Name: "master"},
+	}
 	target := vcsclient.BranchInfo{Owner: "owner", Repository: "repo", Name: "master"}
 
 	assert.Equal(t, "abc123", resolveTargetRef(scanDetails, target, "feature"))
@@ -1784,6 +1788,10 @@ func TestResolveTargetRefWarnsWhenProviderUnsupported(t *testing.T) {
 		Return(vcsclient.CommitInfo{}, vcsclient.ErrMergeBaseUnsupported)
 
 	scanDetails := utils.NewScanDetails(client, &coreconfig.ServerDetails{}, &utils.Git{})
+	scanDetails.PullRequestDetails = vcsclient.PullRequestInfo{
+		Source: vcsclient.BranchInfo{Owner: "owner", Repository: "repo", Name: "feature"},
+		Target: vcsclient.BranchInfo{Owner: "owner", Repository: "repo", Name: "master"},
+	}
 	target := vcsclient.BranchInfo{Owner: "owner", Repository: "repo", Name: "master"}
 
 	assert.Equal(t, "master", resolveTargetRef(scanDetails, target, "feature"))
@@ -1802,8 +1810,53 @@ func TestResolveTargetRefWarnsOnApiFailure(t *testing.T) {
 		Return(vcsclient.CommitInfo{}, errors.New("vcs api is down"))
 
 	scanDetails := utils.NewScanDetails(client, &coreconfig.ServerDetails{}, &utils.Git{})
+	scanDetails.PullRequestDetails = vcsclient.PullRequestInfo{
+		Source: vcsclient.BranchInfo{Owner: "owner", Repository: "repo", Name: "feature"},
+		Target: vcsclient.BranchInfo{Owner: "owner", Repository: "repo", Name: "master"},
+	}
 	target := vcsclient.BranchInfo{Owner: "owner", Repository: "repo", Name: "master"}
 
 	assert.Equal(t, "master", resolveTargetRef(scanDetails, target, "feature"))
 	assert.Contains(t, output.String(), "vcs api is down")
+}
+
+func TestResolveTargetRefSkipsForkPullRequests(t *testing.T) {
+	originalLogger := log.GetLogger()
+	t.Cleanup(func() { log.SetLogger(originalLogger) })
+	var output bytes.Buffer
+	log.SetLogger(log.NewLogger(log.INFO, &output))
+
+	client := CreateMockVcsClient(t)
+	scanDetails := utils.NewScanDetails(client, &coreconfig.ServerDetails{}, &utils.Git{
+		VcsInfo: vcsclient.VcsInfo{},
+	})
+	scanDetails.PullRequestDetails = vcsclient.PullRequestInfo{
+		Source: vcsclient.BranchInfo{Owner: "contributor", Repository: "repo", Name: "feature"},
+		Target: vcsclient.BranchInfo{Owner: "upstream", Repository: "repo", Name: "master"},
+	}
+	target := vcsclient.BranchInfo{Owner: "upstream", Repository: "repo", Name: "master"}
+
+	assert.Equal(t, "master", resolveTargetRef(scanDetails, target, "feature"))
+	assert.Contains(t, output.String(), "fork")
+}
+
+func TestResolveTargetRefFallsBackOnEmptyMergeBase(t *testing.T) {
+	originalLogger := log.GetLogger()
+	t.Cleanup(func() { log.SetLogger(originalLogger) })
+	var output bytes.Buffer
+	log.SetLogger(log.NewLogger(log.INFO, &output))
+
+	client := CreateMockVcsClient(t)
+	client.EXPECT().GetMergeBase(context.Background(), "owner", "repo", "master", "feature").
+		Return(vcsclient.CommitInfo{}, nil)
+
+	scanDetails := utils.NewScanDetails(client, &coreconfig.ServerDetails{}, &utils.Git{})
+	scanDetails.PullRequestDetails = vcsclient.PullRequestInfo{
+		Source: vcsclient.BranchInfo{Owner: "owner", Repository: "repo", Name: "feature"},
+		Target: vcsclient.BranchInfo{Owner: "owner", Repository: "repo", Name: "master"},
+	}
+	target := vcsclient.BranchInfo{Owner: "owner", Repository: "repo", Name: "master"}
+
+	assert.Equal(t, "master", resolveTargetRef(scanDetails, target, "feature"))
+	assert.Contains(t, output.String(), "empty")
 }

--- a/scanpullrequest/scanpullrequest_test.go
+++ b/scanpullrequest/scanpullrequest_test.go
@@ -1869,17 +1869,17 @@ func TestDownloadTargetRetriesAtBranchTipWhenMergeBaseDownloadFails(t *testing.T
 
 	const mergeBaseSha = "5d5479f857362d9eb668b6403631e57f0d3d3ba6"
 	var requested []string
-	download := func(_ vcsclient.VcsClient, _, _, ref string) (string, func() error, error) {
+	downloadCommit := func(_ vcsclient.VcsClient, _, _, ref string) (string, func() error, error) {
 		requested = append(requested, ref)
-		if ref == mergeBaseSha {
-			return "", nil, errors.New("404 Not Found")
-		}
-		dir := t.TempDir()
-		return dir, func() error { return nil }, nil
+		return "", nil, errors.New("404 Not Found")
+	}
+	downloadBranch := func(_ vcsclient.VcsClient, _, _, ref string) (string, func() error, error) {
+		requested = append(requested, ref)
+		return t.TempDir(), func() error { return nil }, nil
 	}
 	target := vcsclient.BranchInfo{Owner: "owner", Repository: "repo", Name: "master"}
 
-	wd, cleanup, err := downloadTargetAtRef(nil, target, mergeBaseSha, download)
+	wd, cleanup, err := downloadTargetAtRef(nil, target, mergeBaseSha, downloadCommit, downloadBranch)
 
 	assert.NoError(t, err)
 	assert.NotEmpty(t, wd)
@@ -1890,13 +1890,17 @@ func TestDownloadTargetRetriesAtBranchTipWhenMergeBaseDownloadFails(t *testing.T
 
 func TestDownloadTargetDoesNotRetryWhenAlreadyAtBranchTip(t *testing.T) {
 	var requested []string
-	download := func(_ vcsclient.VcsClient, _, _, ref string) (string, func() error, error) {
+	downloadCommit := func(_ vcsclient.VcsClient, _, _, ref string) (string, func() error, error) {
+		requested = append(requested, "commit:"+ref)
+		return "", nil, errors.New("should not be called")
+	}
+	downloadBranch := func(_ vcsclient.VcsClient, _, _, ref string) (string, func() error, error) {
 		requested = append(requested, ref)
 		return "", nil, errors.New("network is down")
 	}
 	target := vcsclient.BranchInfo{Owner: "owner", Repository: "repo", Name: "master"}
 
-	_, _, err := downloadTargetAtRef(nil, target, "master", download)
+	_, _, err := downloadTargetAtRef(nil, target, "master", downloadCommit, downloadBranch)
 
 	assert.Error(t, err)
 	assert.Equal(t, []string{"master"}, requested, "no pointless second attempt at the same ref")

--- a/scanpullrequest/scanpullrequest_test.go
+++ b/scanpullrequest/scanpullrequest_test.go
@@ -1860,3 +1860,44 @@ func TestResolveTargetRefFallsBackOnEmptyMergeBase(t *testing.T) {
 	assert.Equal(t, "master", resolveTargetRef(scanDetails, target, "feature"))
 	assert.Contains(t, output.String(), "empty")
 }
+
+func TestDownloadTargetRetriesAtBranchTipWhenMergeBaseDownloadFails(t *testing.T) {
+	originalLogger := log.GetLogger()
+	t.Cleanup(func() { log.SetLogger(originalLogger) })
+	var output bytes.Buffer
+	log.SetLogger(log.NewLogger(log.INFO, &output))
+
+	const mergeBaseSha = "5d5479f857362d9eb668b6403631e57f0d3d3ba6"
+	var requested []string
+	download := func(_ vcsclient.VcsClient, _, _, ref string) (string, func() error, error) {
+		requested = append(requested, ref)
+		if ref == mergeBaseSha {
+			return "", nil, errors.New("404 Not Found")
+		}
+		dir := t.TempDir()
+		return dir, func() error { return nil }, nil
+	}
+	target := vcsclient.BranchInfo{Owner: "owner", Repository: "repo", Name: "master"}
+
+	wd, cleanup, err := downloadTargetAtRef(nil, target, mergeBaseSha, download)
+
+	assert.NoError(t, err)
+	assert.NotEmpty(t, wd)
+	assert.NotNil(t, cleanup)
+	assert.Equal(t, []string{mergeBaseSha, "master"}, requested, "must retry at the branch tip")
+	assert.Contains(t, output.String(), "scanning the tip of master instead")
+}
+
+func TestDownloadTargetDoesNotRetryWhenAlreadyAtBranchTip(t *testing.T) {
+	var requested []string
+	download := func(_ vcsclient.VcsClient, _, _, ref string) (string, func() error, error) {
+		requested = append(requested, ref)
+		return "", nil, errors.New("network is down")
+	}
+	target := vcsclient.BranchInfo{Owner: "owner", Repository: "repo", Name: "master"}
+
+	_, _, err := downloadTargetAtRef(nil, target, "master", download)
+
+	assert.Error(t, err)
+	assert.Equal(t, []string{"master"}, requested, "no pointless second attempt at the same ref")
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -291,6 +291,18 @@ func generateFrogbotSarifReport(extendedResults *results.SecurityCommandResults)
 }
 
 func DownloadRepoToTempDir(client vcsclient.VcsClient, repoOwner, repoName, branch string) (wd string, cleanup func() error, err error) {
+	return downloadRefToTempDir(repoOwner, repoName, branch, func(localPath string) error {
+		return client.DownloadRepository(context.Background(), repoOwner, repoName, branch, localPath)
+	})
+}
+
+func DownloadRepoCommitToTempDir(client vcsclient.VcsClient, repoOwner, repoName, commitSha string) (wd string, cleanup func() error, err error) {
+	return downloadRefToTempDir(repoOwner, repoName, commitSha, func(localPath string) error {
+		return client.DownloadRepositoryByCommit(context.Background(), repoOwner, repoName, commitSha, localPath)
+	})
+}
+
+func downloadRefToTempDir(repoOwner, repoName, ref string, download func(localPath string) error) (wd string, cleanup func() error, err error) {
 	wd, err = fileutils.CreateTempDir()
 	if err != nil {
 		return
@@ -298,9 +310,9 @@ func DownloadRepoToTempDir(client vcsclient.VcsClient, repoOwner, repoName, bran
 	cleanup = func() error {
 		return fileutils.RemoveTempDir(wd)
 	}
-	log.Debug(fmt.Sprintf("Downloading <%s/%s/%s> to: '%s'", repoOwner, repoName, branch, wd))
-	if err = client.DownloadRepository(context.Background(), repoOwner, repoName, branch, wd); err != nil {
-		err = fmt.Errorf("failed to download branch: <%s/%s/%s> with error: %s", repoOwner, repoName, branch, err.Error())
+	log.Debug(fmt.Sprintf("Downloading <%s/%s/%s> to: '%s'", repoOwner, repoName, ref, wd))
+	if err = download(wd); err != nil {
+		err = fmt.Errorf("failed to download branch: <%s/%s/%s> with error: %s", repoOwner, repoName, ref, err.Error())
 		return
 	}
 	log.Debug("Repository download completed")


### PR DESCRIPTION
## Background

PR scans diff the source branch tip against the **target branch tip**. When a branch is behind its target, anything the target gained since the branch point looks newly introduced by the PR — so the target's already-fixed vulnerabilities are reported as new findings on a PR that changed no dependency file.

A customer hit this: two SCA violations for `CVE-2026-41710` on `spring-retry:2.0.12`, on a PR with no `pom.xml` change. Their master already carried `2.0.13` — the CVE's fix version. GitHub's Files-changed view uses the merge base, so nothing looked modified; Frogbot used the tip.

## What changed

`downloadSourceAndTarget` now resolves the merge base through the git provider and downloads the target tree at that commit instead of at the branch tip.

Resolution is two rungs — **provider API, else target tip**:
- Merge base resolved → scan that commit, log it at INFO.
- Provider not yet implemented → scan the target tip, warn that results may contain findings already fixed on the target and that rebasing avoids it.
- Any API error → scan the target tip, warn with the underlying error.

The bottom rung is exactly today's behavior, so no provider can regress. GitHub and GitLab resolve today (jfrog/froggit-go#195); Bitbucket Cloud, Bitbucket Server and Azure Repos take the warned fallback until their own PRs land.

**When the branch is up to date the merge base equals the target tip, so the scan is unchanged. Only stale branches behave differently.**

## Notes for reviewers

- **No generic-git fallback, deliberately.** V2 computed this by fetching full history into a synthetic `.git`; measured on a real monorepo that costs **118.7s / 1.3GB** versus ~480ms for the provider API. A commits-only partial fetch is far better (~9s) but silently degrades to the full fetch when a server refuses the filter — a fallback whose worst case is 250x the happy path. The provider API is also size-independent: 472ms on a 140k-commit repo.
- **`pull_request.base.sha` is not the merge base.** It looks correct and diverged in 11 of 25 sampled `cli/cli` PRs. Only the compare/merge-base endpoints are authoritative.
- Every fallback warns. V2's silent fallback is why its breakage went unnoticed for a year; the warnings are asserted in tests, not just written.

## Blocked on

jfrog/froggit-go#195 must merge and release first. Draft until then — the froggit-go bump is the only remaining commit.

Refs XRAY-133157.